### PR TITLE
Updated PUML links

### DIFF
--- a/usecase-library/UC001-Bootstrap-role-for-component.md
+++ b/usecase-library/UC001-Bootstrap-role-for-component.md
@@ -9,5 +9,5 @@ It uses the following assumptions:
 * The Bootstrap process will also assign the Canvas `seccon` user to the Admin role. This user can be used for all subsequent API calls from the Canvas. The `seccon` user was created as part of the Canvas setup.
 * Once the bootstrap process is complete, when clients of the component call the components exposed Open-APIs, the Canvas will perform the initial authorization and include the Role information in the API call (using HTTP headders and following open standards like SAML or OAuth2). The component can use this to perform access control on the data it masters.
 
-![securitySequenceKeycloak](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/securitySequenceKeycloak.puml)
+![securitySequenceKeycloak](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/securitySequenceKeycloak.puml)
 [plantUML code](pumlFiles/securitySequenceKeycloak.puml)

--- a/usecase-library/UC002-Expose-APIs-for-Component.md
+++ b/usecase-library/UC002-Expose-APIs-for-Component.md
@@ -8,29 +8,29 @@ This use-case describes how a component exposes its APIs for other components an
 
 ## Install component
 
-![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/exposeAPI.puml)
+![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/exposeAPI.puml)
 [plantUML code](pumlFiles/exposeAPI.puml)
 
 ## Upgrade component - with changed API
 
 The use-case above is for the install of a new component. If you upgrade a component and change an API, the configuration of the Service Mesh and/or API Gateway should change.
 
-![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/exposeAPI-upgrade-with-modify.puml)
+![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/exposeAPI-upgrade-with-modify.puml)
 [plantUML code](pumlFiles/exposeAPI-upgrade-with-modify.puml)
 
 ## Upgrade component - with additional API
 
-![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/exposeAPI-upgrade-with-add.puml)
+![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/exposeAPI-upgrade-with-add.puml)
 [plantUML code](pumlFiles/exposeAPI-upgrade-with-add.puml)
 
 ## Upgrade component - with deleted API
 
 
-![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/exposeAPI-upgrade-with-delete.puml)
+![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/exposeAPI-upgrade-with-delete.puml)
 [plantUML code](pumlFiles/exposeAPI-upgrade-with-delete.puml)
 
 ## Delete component 
 
-![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/exposeAPI-delete.puml)
+![exposeAPIs](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/exposeAPI-delete.puml)
 [plantUML code](pumlFiles/exposeAPI-delete.puml)
 

--- a/usecase-library/UC003-Discover-dependent-APIs-for-Component.md
+++ b/usecase-library/UC003-Discover-dependent-APIs-for-Component.md
@@ -7,5 +7,5 @@ This use-case describes how a component discovers the url and credentials for a 
 * The ODA Components are **not** given raised privelages to query the Canvas to find their dependencies; Instead, the operations team read the requirement from the Component definition and provides details of the dependent APIs back to the component in the `values.yaml` file. For example, in a Kubernetes based Canvas, the Components are **not** given the permission to call the Kubernetes API. This is important from a security perspective as well as from the perspective of not building operational dependencies on management-plane APIs.
 
 
-![discoverDependentAPI](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/discoverDependentAPI.puml)
+![discoverDependentAPI](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/discoverDependentAPI.puml)
 [plantUML code](pumlFiles/discoverDependentAPI.puml)

--- a/usecase-library/UC005-View-Baseline-Observability.md
+++ b/usecase-library/UC005-View-Baseline-Observability.md
@@ -1,4 +1,4 @@
 # View baseline observability for component use-case
 
-![baselineObservabilityIstioKiali](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/baselineObservabilityIstioKiali.puml)
+![baselineObservabilityIstioKiali](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/baselineObservabilityIstioKiali.puml)
 [plantUML code](pumlFiles/baselineObservabilityIstioKiali.puml)

--- a/usecase-library/UC006-View-Custom-Observability.md
+++ b/usecase-library/UC006-View-Custom-Observability.md
@@ -1,4 +1,4 @@
 # View custom business metric observability for component use-case
 
-![customObservabilityMetricService](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/customObservability.puml)
+![customObservabilityMetricService](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/customObservability.puml)
 [plantUML code](pumlFiles/customObservability.puml)

--- a/usecase-library/UC007-Authentication-external.md
+++ b/usecase-library/UC007-Authentication-external.md
@@ -9,12 +9,12 @@ When an external system client wants to call an API exposed by a Component, this
 *Refer to [Which OAuth2 flow should I use](https://auth0.com/docs/get-started/authentication-and-authorization-flow/which-oauth-2-0-flow-should-i-use)
 ## Access Management
 
-![authentication-external-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/access-management.puml)
+![authentication-external-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/access-management.puml)
 [plantUML code](pumlFiles/access-management.puml)
 
 ## System User Authentication
 
-![authentication-external-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/authentication-external-system.puml)
+![authentication-external-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/authentication-external-system.puml)
 [plantUML code](pumlFiles/authentication-external-system.puml)
 
 

--- a/usecase-library/UC008-Authentication-internal.md
+++ b/usecase-library/UC008-Authentication-internal.md
@@ -12,5 +12,5 @@ When one deployed component wants to call an API exposed by another component (i
 *Refer to [Which OAuth2 flow should I use](https://auth0.com/docs/get-started/authentication-and-authorization-flow/which-oauth-2-0-flow-should-i-use)
 ## Authentication
 
-![authentication-internal-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas-ctk/canvasUseCasesandBDD/usecase-library/pumlFiles/authentication-internal-system.puml)
+![authentication-internal-system](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/tmforum-oda/oda-canvas/master/usecase-library/pumlFiles/authentication-internal-system.puml)
 [plantUML code](pumlFiles/authentication-internal-system.puml)


### PR DESCRIPTION
The PUML links were to the old oda-canvas-ctk repository. This PR fixes that.