### PR TITLE
fix Feature:Canvas support arm64 cpu architecture

### DIFF
--- a/installation/canvas-oda/values.yaml
+++ b/installation/canvas-oda/values.yaml
@@ -45,11 +45,15 @@ cert-manager-init:
 
 keycloak:
   enabled: true
+  image:
+    tag: 20.0.5-debian-11-r2
   auth:
     adminUser: "admin"
     adminPassword: "adpass"
   postgresql:
     enabled: true
+    image:
+      tag: 15.2.0-debian-11-r31
     auth:
       username: "keycloak"
       password: "keycloakdbuser"
@@ -74,6 +78,8 @@ keycloak:
   # -- Create a myrealm realm with a seccon user
   keycloakConfigCli:
     enabled: true
+    image:
+      tag: 5.5.0-debian-11-r35
     backoffLimit: 1
     command: [ "java", "-jar", "/opt/keycloak-config-cli.jar" ]
     configuration:

--- a/source/operators/buildControllers.sh
+++ b/source/operators/buildControllers.sh
@@ -1,11 +1,14 @@
 #docker build --file component-IngressController-dockerfile -t tmforumodacanvas/component-controller:0.14.1 .
 #docker push tmforumodacanvas/component-controller --all-tags
-docker build --file component-IstioController-dockerfile -t tmforumodacanvas/component-istio-controller:0.2.7 .
-docker push tmforumodacanvas/component-istio-controller:0.2.7
+#docker build --file component-IstioController-dockerfile -t tmforumodacanvas/component-istio-controller:0.2.7 .
+#docker push tmforumodacanvas/component-istio-controller:0.2.7
+docker buildx build -t "tmforumodacanvas/component-istio-controller:0.2.6" --platform "linux/amd64,linux/arm64" -f component-IstioController-dockerfile . --push
+
 # TODO We'll add the wso2 controller back in when we've refactored it
 #docker build --file component-wso2Controller-dockerfile -t tmforumodacanvas/component-controller-wso2:0.9 -t tmforumodacanvas/component-controller-wso2:latest -t tmforumodacanvas/component-controller-wso2:master .
 #docker push brianjburton/odacomponentcontroller-wso2  --all-tags
-docker build --file securityControllerAPIserver-keycloak-dockerfile -t tmforumodacanvas/security-listener:0.6.0 .
+#docker build --file securityControllerAPIserver-keycloak-dockerfile -t tmforumodacanvas/security-listener:0.6.0 .
 #docker build --file securityControllerAPIserver-keycloak-dockerfile -t tmforumodacanvas/security-listener:0.6.0 -t tmforumodacanvas/security-listener:latest -t tmforumodacanvas/security-listener:master .
-docker push tmforumodacanvas/security-listener  --all-tags
+#docker push tmforumodacanvas/security-listener  --all-tags
+docker buildx build -t "tmforumodacanvas/security-listener:0.6.0" --platform "linux/amd64,linux/arm64" -f securityControllerAPIserver-keycloak-dockerfile . --push
 


### PR DESCRIPTION
To support both arm64 and amd64 architectures :
1.
Upgraded Keycloak:
   From version 20.0.3-debian-11-r5 to 20.0.5-debian-11-r2
Upgraded keycloak-config-cli:
   From version 5.5.0-debian-11-r23 to 5.5.0-debian-11-r35
Upgraded postgresql:
   From version 15.1.0-debian-11-r20 to 15.2.0-debian-11-r31
2.
Modified the oda-canvas/source/operators/buildControllers.sh script to support for both arm64 and amd64 architectures.

close #86 