### PR TITLE
ODAA-86: rollback HashiCorp Vault version to 1.14.8 (MPL)

### DIFF
--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -15,9 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
-# version: upcoming
-#          - ODAA-86: downgrade HashiCorp Vault to 1.14.8 (last version under MPL)
+version: 1.1.5
+# version: 1.1.5 - ODAA-86: downgrade HashiCorp Vault to 1.14.8 (last version under MPL)
 # version: 1.1.4 - added secretsmanagement-operator
 # version: 1.1.3 - updated dependentApiSimpleOperator to tmforum docker repo
 # version: 1.1.2 - added dependentApiSimpleOperator

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -16,6 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.4
+# version: upcoming
+#          - ODAA-86: downgrade HashiCorp Vault to 1.14.8 (last version under MPL)
 # version: 1.1.4 - added secretsmanagement-operator
 # version: 1.1.3 - updated dependentApiSimpleOperator to tmforum docker repo
 # version: 1.1.2 - added dependentApiSimpleOperator
@@ -54,7 +56,7 @@ dependencies:
     version: "0.1.0"
     repository: 'file://../secretsmanagement-operator'
   - name: canvas-vault
-    version: "0.1.0"
+    version: "0.2.0"
     repository: 'file://../canvas-vault'
     condition: canvas-vault.enabled
   - name: oda-webhook

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -16,7 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.5
-# version: 1.1.5 - ODAA-86: downgrade HashiCorp Vault to 1.14.8 (last version under MPL)
+# version: 1.1.5 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 
+#                  see https://www.hashicorp.com/license-faq#products-covered-by-bsl
 # version: 1.1.4 - added secretsmanagement-operator
 # version: 1.1.3 - updated dependentApiSimpleOperator to tmforum docker repo
 # version: 1.1.2 - added dependentApiSimpleOperator

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -15,8 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.5
-# version: 1.1.5 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 
+version: 1.1.5-rc1
+# version: 1.1.5-r1 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 
 #                  see https://www.hashicorp.com/license-faq#products-covered-by-bsl
 # version: 1.1.4 - added secretsmanagement-operator
 # version: 1.1.3 - updated dependentApiSimpleOperator to tmforum docker repo

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -154,9 +154,10 @@ canvas-vault:
     global:
       namespace: "canvas-vault"
     server:
-      #image:
-      #  repository: "dockerhub.devops.telekom.de/hashicorp/vault"
-    
+      image:
+        # last version with MPL license
+        tag: "1.14.8"
+          
       # Run Vault in "dev" mode. This requires no further setup, no state management,
       # and no initialization. This is useful for experimenting with Vault without
       # needing to unseal, store keys, et. al. All data is lost on restart - do not
@@ -205,6 +206,16 @@ canvas-vault:
       # True if you want to enable vault agent injection.
       # @default: global.enabled
       enabled: false
+      
+      agentImage:
+        # last version with MPL license
+        tag: "1.14.8"
+
+    csi:
+      agent:
+        image:
+          # last version with MPL license
+          tag: "1.14.8"
 
 secretsmanagement-operator:
   image: ocfork/secretsmanagement-operator

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -15,13 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
+# version: 0.2.0 - rollback to Vault version 1.14.8, which is the last under MPL
+# version: 0.1.0 - baseline version
 
 # This is the version number of the application being deployed. We are versioning the canvas as the
 # version of the latest component spec that it supports.
-appVersion: "0.28.0"
+appVersion: "0.25.0"
 
 dependencies:
   - name: vault
-    version: "0.28.0"
+    version: "0.25.0"
     repository: 'https://helm.releases.hashicorp.com'

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -21,9 +21,9 @@ version: 0.2.0
 
 # This is the version number of the application being deployed. We are versioning the canvas as the
 # version of the latest component spec that it supports.
-appVersion: "0.25.0"
+appVersion: "1.14.8"
 
 dependencies:
   - name: vault
-    version: "0.25.0"
+    version: "0.26.1"
     repository: 'https://helm.releases.hashicorp.com'

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -16,7 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
-# version: 0.2.0 - rollback to Vault version 1.14.8, which is the last under MPL
+# version: 0.2.0 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 
+#                  see https://www.hashicorp.com/license-faq#products-covered-by-bsl
 # version: 0.1.0 - baseline version
 
 # This is the version number of the application being deployed. We are versioning the canvas as the

--- a/charts/canvas-vault/values.yaml
+++ b/charts/canvas-vault/values.yaml
@@ -25,6 +25,11 @@ vault:
   
       # Set VAULT_DEV_ROOT_TOKEN_ID value
       devRootToken: "egalegal"
+    
+    image:
+      # last version with MPL license
+      tag: "1.14.8"
+
   
   
     # Settings for the statefulSet used to run Vault.
@@ -64,3 +69,13 @@ vault:
     # True if you want to enable vault agent injection.
     # @default: global.enabled
     enabled: false
+    
+    agentImage:
+      # last version with MPL license
+      tag: "1.14.8"
+
+  csi:
+    agent:
+      image:
+        # last version with MPL license
+        tag: "1.14.8"

--- a/installation/CanvasVault/setup_CanvasVault.sh
+++ b/installation/CanvasVault/setup_CanvasVault.sh
@@ -46,8 +46,8 @@ echo -e "${Y}Deploy and configure HashiCorp Vault (in DEV mode)${NC}"
 echo -e "${Y}Installing HashiCorp Vault in DEV mode${NC}"
 helm repo add hashicorp https://helm.releases.hashicorp.com
 helm repo update
-helm upgrade --install canvas-vault-hc hashicorp/vault --namespace canvas-vault --create-namespace --values ./values.yaml --set=server.dev.devRootToken=$VAULT_DEV_ROOT_TOKEN_ID --wait
-             # --version 0.24.0
+helm upgrade --install canvas-vault-hc hashicorp/vault --version 0.25.0  --namespace canvas-vault --create-namespace --values ./values.yaml --set=server.dev.devRootToken=$VAULT_DEV_ROOT_TOKEN_ID --wait
+             
 
 echo "waiting up to 30 seconds for the vault to be ready"
 kubectl -n canvas-vault wait -l  statefulset.kubernetes.io/pod-name=canvas-vault-hc-0 --for=condition=ready pod --timeout=30s

--- a/installation/CanvasVault/setup_CanvasVault.sh
+++ b/installation/CanvasVault/setup_CanvasVault.sh
@@ -46,7 +46,7 @@ echo -e "${Y}Deploy and configure HashiCorp Vault (in DEV mode)${NC}"
 echo -e "${Y}Installing HashiCorp Vault in DEV mode${NC}"
 helm repo add hashicorp https://helm.releases.hashicorp.com
 helm repo update
-helm upgrade --install canvas-vault-hc hashicorp/vault --version 0.25.0  --namespace canvas-vault --create-namespace --values ./values.yaml --set=server.dev.devRootToken=$VAULT_DEV_ROOT_TOKEN_ID --wait
+helm upgrade --install canvas-vault-hc hashicorp/vault --version 0.26.1  --namespace canvas-vault --create-namespace --values ./values.yaml --set=server.dev.devRootToken=$VAULT_DEV_ROOT_TOKEN_ID --wait
              
 
 echo "waiting up to 30 seconds for the vault to be ready"

--- a/installation/CanvasVault/values.yaml
+++ b/installation/CanvasVault/values.yaml
@@ -9,6 +9,10 @@ server:
 
     # Set VAULT_DEV_ROOT_TOKEN_ID value
     devRootToken: "egalegal"
+    
+  image:
+    # last version with MPL license
+    tag: "1.14.8"
 
 
   # Settings for the statefulSet used to run Vault.
@@ -48,3 +52,15 @@ injector:
   # True if you want to enable vault agent injection.
   # @default: global.enabled
   enabled: false
+
+    
+  agentImage:
+    # last version with MPL license
+    tag: "1.14.8"
+
+
+csi:
+  agent:
+    image:
+      # last version with MPL license
+      tag: "1.14.8"


### PR DESCRIPTION
For details see https://projects.tmforum.org/jira/browse/ODAA-86

Testdeployment and running the BDD tests was successful:
https://reports.cucumber.io/reports/4efd415f-0884-4141-aae1-bc307ed29c9b

Manual testing the SecretsManagement Demo was also successful.

![image](https://github.com/tmforum-oda/oda-canvas/assets/11094156/6872cdee-958e-442e-a058-d945aa5843f7)

The sub-chart canvas-vault was updated from version 0.1.0 to 0.2.0.
I am not sure how to handle the canvas-oda chart version number, because we discussed to create only one update per month.
