### PR TITLE
Corrected capitalization in step names.

### DIFF
--- a/feature-definition-and-test-kit/features/UC002-F001-Install-Component.feature
+++ b/feature-definition-and-test-kit/features/UC002-F001-Install-Component.feature
@@ -7,7 +7,7 @@
 Feature: UC002-F001 Install Component
 
     Scenario Outline: Create ExposedAPI resources for each segment
-        Given An example package '<PackageName>' with a '<ComponentName>' component with '<ExposedApiCount>' ExposedAPI in its '<SegmentName>' segment
+        Given an example package '<PackageName>' with a '<ComponentName>' component with '<ExposedApiCount>' ExposedAPI in its '<SegmentName>' segment
         When I install the '<PackageName>' package as release '<ReleaseName>'
         Then I should see the '<ExposedAPIName>' ExposedAPI resource on the '<ComponentName>' component
 
@@ -18,7 +18,7 @@ Feature: UC002-F001 Install Component
     | Security API   | productcatalog-v1beta3 |      pc     | partyrole                | productcatalogmanagement | securityFunction   | 1               |
 
     Scenario Outline: Create DependentAPI resources for each segment
-        Given An example package '<PackageName>' with a '<ComponentName>' component with '<DependentApiCount>' DependentAPI in its '<SegmentName>' segment
+        Given an example package '<PackageName>' with a '<ComponentName>' component with '<DependentApiCount>' DependentAPI in its '<SegmentName>' segment
         When I install the '<PackageName>' package as release '<ReleaseName>'
         Then I should see the '<DependentAPIName>' DependentAPI resource on the '<ComponentName>' component
 

--- a/feature-definition-and-test-kit/features/UC002-F002-Upgrade-Component.feature
+++ b/feature-definition-and-test-kit/features/UC002-F002-Upgrade-Component.feature
@@ -7,19 +7,19 @@
 Feature: UC002-F002 Upgrade Component
 
     Scenario Outline: Updated component with added ExposedAPI resources
-        Given A baseline 'productcatalog-v1beta3' package installed as release 'pc'
-        Given An example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
+        Given a baseline 'productcatalog-v1beta3' package installed as release 'pc'
+        Given an example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
         When I upgrade the 'productcatalog-enhanced-v1beta3' package as release 'pc'
         Then I should see the 'promotionmanagement' ExposedAPI resource on the 'productcatalogmanagement' component
 
     Scenario Outline: Updated component with removed ExposedAPI resources
-        Given A baseline 'productcatalog-enhanced-v1beta3' package installed as release 'pc'
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given a baseline 'productcatalog-enhanced-v1beta3' package installed as release 'pc'
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I upgrade the 'productcatalog-v1beta3' package as release 'pc'
         Then I should not see the 'promotionmanagement' ExposedAPI resource on the 'productcatalogmanagement' component
 
     Scenario Outline: Updated component with updated ExposedAPI resources
-        Given A baseline 'productcatalog-v1beta3' package installed as release 'pc'
-        Given An example package 'productcatalog-updated-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given a baseline 'productcatalog-v1beta3' package installed as release 'pc'
+        Given an example package 'productcatalog-updated-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I upgrade the 'productcatalog-updated-v1beta3' package as release 'pc'
         Then I should see the 'productcatalogmanagement' ExposedAPI resource on the 'productcatalogmanagement' component with specification 'https://raw.githubusercontent.com/tmforum-apis/TMF620_ProductCatalog/master/TMF620-ProductCatalog-v4.0.1.swagger.json'

--- a/feature-definition-and-test-kit/features/UC003-F001-Expose-APIs-Create-API-Resource.feature
+++ b/feature-definition-and-test-kit/features/UC003-F001-Expose-APIs-Create-API-Resource.feature
@@ -7,7 +7,7 @@
 Feature: UC003-F001 Expose APIs: Create API Resource
 
     Scenario Outline: Create API Resource for API
-        Given An example package '<PackageName>' with a '<ComponentName>' component with '<ApiCount>' ExposedAPI in its '<SegmentName>' segment
+        Given an example package '<PackageName>' with a '<ComponentName>' component with '<ApiCount>' ExposedAPI in its '<SegmentName>' segment
         When I install the '<PackageName>' package
         Then I should see the '<ResourceName>' ExposedAPI resource on the '<ComponentName>' component
 

--- a/feature-definition-and-test-kit/features/UC003-F002-Expose-APIs-Publish-API-Resource-URL.feature
+++ b/feature-definition-and-test-kit/features/UC003-F002-Expose-APIs-Publish-API-Resource-URL.feature
@@ -7,17 +7,17 @@
 Feature: UC003-F002 Expose APIs: Publish API Resource URL
 
     Scenario: Test API Resource URL for Core API
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'productcatalogmanagement' ExposedAPI resource on the 'productcatalogmanagement' component with a url on the Service Mesh or Gateway
 
     Scenario: Test API Resource URL for Management API
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'managementFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'managementFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'metrics' ExposedAPI resource on the 'productcatalogmanagement' component with a url on the Service Mesh or Gateway
 
     Scenario: Test API Resource URL for Security API
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'securityFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'securityFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'partyrole' ExposedAPI resource on the 'productcatalogmanagement' component with a url on the Service Mesh or Gateway
 

--- a/feature-definition-and-test-kit/features/UC003-F003-Expose-APIs-Verify-API-implementation-is-ready.feature
+++ b/feature-definition-and-test-kit/features/UC003-F003-Expose-APIs-Verify-API-implementation-is-ready.feature
@@ -7,17 +7,17 @@
 Feature: UC003-F003 Expose APIs: Verify API implementation is ready
 
     Scenario: Verify ExposedAPI Resource is ready for Core ExposedAPI
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'productcatalogmanagement' ExposedAPI resource on the 'productcatalogmanagement' component with an implementation ready status on the Service Mesh or Gateway
 
     Scenario: Verify ExposedAPI Resource is ready for Management ExposedAPI
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'managementFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'managementFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'metrics' ExposedAPI resource on the 'productcatalogmanagement' component with an implementation ready status on the Service Mesh or Gateway
 
     Scenario: Verify ExposedAPI Resource is ready for Security ExposedAPI
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'securityFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'securityFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I should see the 'partyrole' ExposedAPI resource on the 'productcatalogmanagement' component with an implementation ready status on the Service Mesh or Gateway
 

--- a/feature-definition-and-test-kit/features/UC003-F004-Expose-APIs-Upgrade-component-with-additional-API.feature
+++ b/feature-definition-and-test-kit/features/UC003-F004-Expose-APIs-Upgrade-component-with-additional-API.feature
@@ -7,12 +7,12 @@
 Feature: UC003-F004 Expose APIs: Upgrade component with additional ExposedAPI
 
     Background:
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta3' package
         And the 'productcatalogmanagement' component has a deployment status of 'Complete'
      
     Scenario: Upgrade component with additional ExposedAPI in coreFunction
-        Given An example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
         When I upgrade the 'productcatalog-enhanced-v1beta3' package
         And the 'productcatalogmanagement' component has a deployment status of 'Complete'
         Then I should see the 'promotionmanagement' ExposedAPI resource on the 'productcatalogmanagement' component

--- a/feature-definition-and-test-kit/features/UC003-F005-Expose-APIs-Upgrade-component-with-removed-API.feature
+++ b/feature-definition-and-test-kit/features/UC003-F005-Expose-APIs-Upgrade-component-with-removed-API.feature
@@ -7,11 +7,11 @@
 Feature: UC003-F005 Expose APIs: Upgrade component with removed API
 
     Background:
-        Given An example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-enhanced-v1beta3' with a 'productcatalogmanagement' component with '2' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-enhanced-v1beta3' package
         # And the 'productcatalog' component has a deployment status of 'Complete' - won't work at the moment as there is no ExposedAPI implementation for promotionmanagement
      
     Scenario: Upgrade component with removed ExposedAPI in coreFunction
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I upgrade the 'productcatalog-v1beta3' package
         Then I should not see the 'promotionmanagement' ExposedAPI resource on the 'productcatalogmanagement' component

--- a/feature-definition-and-test-kit/features/UC005-F001-Bootstrap-Apply-Standard-Defined-Role-to-Canvas-Admin-user.feature
+++ b/feature-definition-and-test-kit/features/UC005-F001-Bootstrap-Apply-Standard-Defined-Role-to-Canvas-Admin-user.feature
@@ -10,7 +10,7 @@
 Feature: UC005-F001 Bootstrap:Apply Standard Defined Role to Canvas Admin user
 
     Scenario: Create role for security user in the identity platform
-        Given An example package 'productcatalog-v1beta3' has been installed
+        Given an example package 'productcatalog-v1beta3' has been installed
         When the 'productcatalogmanagement' component has a deployment status of 'Complete'
         Then I should see the predefined role assigned to the 'seccon' user for the 'productcatalogmanagement' component in the identity platform
 

--- a/feature-definition-and-test-kit/features/UC005-F005-Bootstrap-Add-Permission-Specification-Sets-in-Component-to-Identity-Platform.feature
+++ b/feature-definition-and-test-kit/features/UC005-F005-Bootstrap-Add-Permission-Specification-Sets-in-Component-to-Identity-Platform.feature
@@ -7,7 +7,7 @@
 Feature: UC005-F005 Bootstrap: Add Permission Specification Sets in Component to Identity Platform
 
     Scenario Outline: Add Permission Specification Sets in Component to Identity Platform
-        Given An example package '<PackageName>' with a '<ComponentName>' component with '<Number>' existing roles
+        Given an example package '<PackageName>' with a '<ComponentName>' component with '<Number>' existing roles
         And '<PackageName>' exposes permission specification sets using '<Type>'
         When I install the '<PackageName>' package
         Then I should see all '<Number>' roles listed against the client '<PackageName>' in the Identity Platform

--- a/feature-definition-and-test-kit/features/UC013-F001-Seamless-upgrades-Installing-components-using-prev-version.feature
+++ b/feature-definition-and-test-kit/features/UC013-F001-Seamless-upgrades-Installing-components-using-prev-version.feature
@@ -7,12 +7,12 @@
 Feature: UC013-F001 Seamless upgrade: Installing component using previous version
 
     Scenario: Installing a component using a previous (N-1) version
-        Given An example package 'productcatalog-v1beta2' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta2' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta2' package
         Then I can query the 'v1beta3' spec version of the 'productcatalogmanagement' component
 
     Scenario: Installing a component using a previous (N-2) version
-        Given An example package 'productcatalog-v1beta1' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta1' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta1' package
         Then I can query the 'v1beta3' spec version of the 'productcatalogmanagement' component
     

--- a/feature-definition-and-test-kit/features/UC013-F002-Seamless-upgrades-Canvas-Operators-using-prev-version.feature
+++ b/feature-definition-and-test-kit/features/UC013-F002-Seamless-upgrades-Canvas-Operators-using-prev-version.feature
@@ -7,12 +7,12 @@
 Feature: UC013-F002 Seamless upgrade: Canvas operators using previous version
 
     Scenario: Installing a component and testing access using a previous (N-1) version
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I can query the 'v1beta2' spec version of the 'productcatalogmanagement' component
     
     Scenario: Installing a component and testing access using a previous (N-2) version
-        Given An example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
+        Given an example package 'productcatalog-v1beta3' with a 'productcatalogmanagement' component with '1' ExposedAPI in its 'coreFunction' segment
         When I install the 'productcatalog-v1beta3' package
         Then I can query the 'v1beta1' spec version of the 'productcatalogmanagement' component
 

--- a/feature-definition-and-test-kit/features/step-definition/ComponentManagementSteps.js
+++ b/feature-definition-and-test-kit/features/step-definition/ComponentManagementSteps.js
@@ -35,7 +35,7 @@ setDefaultTimeout( 20 * 1000);
  * @param {string} numberOfAPIs - The expected number of ExposedAPIs in the component segment.
  * @param {string} componentSegmentName - The name of the component segment.
  */
-Given('An example package {string} with a {string} component with {string} ExposedAPI in its {string} segment', async function (componentPackage, componentName, numberOfAPIs, componentSegmentName) {
+Given('an example package {string} with a {string} component with {string} ExposedAPI in its {string} segment', async function (componentPackage, componentName, numberOfAPIs, componentSegmentName) {
   exposedAPIs = packageManagerUtils.getExposedAPIsFromPackage(componentPackage, 'ctk', componentSegmentName)
   // assert that there are the correct number of ExposedAPIs in the componentSegment
   assert.ok(exposedAPIs.length == numberOfAPIs, "The componentSegment should contain " + numberOfAPIs + " ExposedAPI")
@@ -49,7 +49,7 @@ Given('An example package {string} with a {string} component with {string} Expos
  * @param {string} numberOfAPIs - The expected number of DependentAPIs in the component segment.
  * @param {string} componentSegmentName - The name of the component segment.
  */
-Given('An example package {string} with a {string} component with {string} DependentAPI in its {string} segment', async function (componentPackage, componentName, numberOfAPIs, componentSegmentName) {
+Given('an example package {string} with a {string} component with {string} DependentAPI in its {string} segment', async function (componentPackage, componentName, numberOfAPIs, componentSegmentName) {
   dependentAPIs = packageManagerUtils.getDependentAPIsFromPackage(componentPackage, 'ctk', componentSegmentName)
   // assert that there are the correct number of DependentAPI in the componentSegment
   assert.ok(dependentAPIs.length == numberOfAPIs, "The componentSegment should contain " + numberOfAPIs + " DependentAPI")
@@ -72,7 +72,7 @@ When('I install the {string} package', async function (componentPackage) {
  * @param {string} componentPackage - The name of the package to install.
  * @param {string} releaseName - The name of the release name.
  */
-Given('A baseline {string} package installed as release {string}', async function (componentPackage, releaseName) {
+Given('a baseline {string} package installed as release {string}', async function (componentPackage, releaseName) {
   global.currentReleaseName = releaseName
   await packageManagerUtils.installPackage(componentPackage, global.currentReleaseName, NAMESPACE)
 });
@@ -105,7 +105,7 @@ When('I upgrade the {string} package as release {string}', async function (compo
  *
  * @param {string} componentPackage - The name of the example component package to install.
  */
-Given('An example package {string} has been installed', async function (componentPackage) {
+Given('an example package {string} has been installed', async function (componentPackage) {
   global.currentReleaseName = DEFAULT_RELEASE_NAME
   await packageManagerUtils.installPackage(componentPackage, global.currentReleaseName, NAMESPACE)
 });


### PR DESCRIPTION
Just small corrections on the capitalization in two steps

Before it look like
  `Given A baseline 'productcatalog-enhanced-v1beta3' package installed as release 'pc'`
  `Given An example package 'productcatalog-updated-v1beta3' with a 'productcatalogmanagement'  ...`

After
  `Given a baseline 'productcatalog-enhanced-v1beta3' package installed as release 'pc'`
  `Given an example package 'productcatalog-updated-v1beta3' with a 'productcatalogmanagement'  ...`
