### PR TITLE
Automate Docker Build: skip tests in step 5 'remove prerelease suffixes'

### DIFF
--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -58,13 +58,13 @@ jobs:
           export NEW_LINES_WITH_EMPTY_PRS=$(cat gitdiff.txt | grep -i "^+ .*prereleasesuffix:\s*$" | wc -l)
 
           echo "OLD LINES ($OLD_LINES)"
-          cat gitdiff.txt | grep -i "^- "
+          cat gitdiff.txt | grep -i "^- " || true
           echo "---- -------------------- ----"
           echo "NEW LINES ($NEW_LINES)"
-          cat gitdiff.txt | grep -i "^+ "
+          cat gitdiff.txt | grep -i "^+ " || true
           echo "---- -------------------- ----"
           echo "NEW LINES WITH EMPTY PRERELEASESUFFIX ($NEW_LINES_WITH_EMPTY_PRS)"
-          cat gitdiff.txt | grep -i "^+ .*prereleasesuffix:\s*$" 
+          cat gitdiff.txt | grep -i "^+ .*prereleasesuffix:\s*$" || true
           echo "---- -------------------- ----"
           
           if [ "$OLD_LINES" != "$NEW_LINES" ]

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         echo "---- CHANGED FILES ----"
         git diff --name-only HEAD~1
+        echo "---- ------------- ----"
         export CHANGED_FILES=$(git diff --name-only HEAD~1)
         if [ "$CHANGED_FILES" == "charts/canvas-oda/values.yaml" ]
         then
@@ -80,6 +81,8 @@ jobs:
               echo "SKIPTESTS=1" >> $GITHUB_OUTPUT
             fi
           fi
+        else
+          echo "changes to other files than values.yaml detected, not skipping tests"
         fi 
 
 

--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -12,13 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.title, '[skip tests]')"
     outputs:
-      SKIPTESTS: ${{ steps.check_skiptests_msg.outputs.SKIPTESTS }}
+      COMMITMSG_SKIPTESTS: ${{ steps.check_skiptests_msg.outputs.SKIPTESTS }}
+      PRERELEASESUFFIX_SKIPTESTS: ${{ steps.check_prereleasesuffixremoval.outputs.SKIPTESTS }}
     steps:
+    
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
+        fetch-depth: 2    # this is needed for getting the diff of the last commit
+        
     - name: Check for [skip tests] in Message
       id: check_skiptests_msg
       run: |
@@ -29,19 +33,64 @@ jobs:
           echo "SKIPPING TESTS"
           echo "SKIPTESTS=1" >> $GITHUB_OUTPUT
         else
-          echo "EXECUTING TESTS"
-          echo "SKIPTESTS=" >> $GITHUB_OUTPUT
+          echo "'[skip tests]' magic words were not found in commit message, not skipping tests"
         fi
+
+    - name: check last commit contains only prerelease suffix removals 
+      id: check_prereleasesuffixremoval
+      shell: bash
+      run: |
+        echo "---- CHANGED FILES ----"
+        git diff --name-only HEAD~1
+        export CHANGED_FILES=$(git diff --name-only HEAD~1)
+        if [ "$CHANGED_FILES" == "charts/canvas-oda/values.yaml" ]
+        then
+          echo "only charts/canvas-oda/values.yaml was changed."
+          echo "checking changes if only prerelease suffixes were removed."
+          
+          echo "---- DIFF FROM LAST COMMIT ----"
+          git diff -w -U0 --color=always HEAD~1
+          echo "---- --------------------- ----"
+          
+          git diff -w -U0 --color=never HEAD~1 > gitdiff.txt
+          export OLD_LINES=$(cat gitdiff.txt | grep -i "^- " | wc -l)
+          export NEW_LINES=$(cat gitdiff.txt | grep -i "^+ " | wc -l)
+          export NEW_LINES_WITH_EMPTY_PRS=$(cat gitdiff.txt | grep -i "^+ .*prereleasesuffix:\s*$" | wc -l)
+
+          echo "OLD LINES ($OLD_LINES)"
+          cat gitdiff.txt | grep -i "^- "
+          echo "---- -------------------- ----"
+          echo "NEW LINES ($NEW_LINES)"
+          cat gitdiff.txt | grep -i "^+ "
+          echo "---- -------------------- ----"
+          echo "NEW LINES WITH EMPTY PRERELEASESUFFIX ($NEW_LINES_WITH_EMPTY_PRS)"
+          cat gitdiff.txt | grep -i "^+ .*prereleasesuffix:\s*$" 
+          echo "---- -------------------- ----"
+          
+          if [ "$OLD_LINES" != "$NEW_LINES" ]
+          then
+            echo "Number of old lines and new lines differs, not skipping tests"
+          else
+            if [ "$NEW_LINES" != "$NEW_LINES_WITH_EMPTY_PRS" ]
+            then
+              echo "not all new lines are empty prereleasesuffixes, not skipping tests"
+            else
+              echo "detected only prerelease suffix removals in changed files"
+              echo "SKIPPING TESTS"
+              echo "SKIPTESTS=1" >> $GITHUB_OUTPUT
+            fi
+          fi
+        fi 
 
 
   run_tests_job:
     runs-on: ubuntu-latest
     needs: check_skip_tests_job    
-    if: "!needs.check_skip_tests_job.outputs.SKIPTESTS"
+    if: "!needs.check_skip_tests_job.outputs.COMMITMSG_SKIPTESTS && !needs.check_skip_tests_job.outputs.PRERELEASESUFFIX_SKIPTESTS"
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -113,7 +113,7 @@ controller:
     controllerName: oda-controller
     compconImage: tmforumodacanvas/component-istio-controller
     compconVersion: 0.5.2
-    compconPrereleaseSuffix: issue123 
+    compconPrereleaseSuffix:  
     imagePullPolicy: IfNotPresent
     istioGateway: true
     secconImage: tmforumodacanvas/security-listener
@@ -259,6 +259,6 @@ secretsmanagement-operator:
 oda-webhook:
   image: tmforumodacanvas/compcrdwebhook
   version: 0.8.2
-  prereleaseSuffix: issue123
+  prereleaseSuffix:
   imagePullPolicy: IfNotPresent
 

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -113,7 +113,7 @@ controller:
     controllerName: oda-controller
     compconImage: tmforumodacanvas/component-istio-controller
     compconVersion: 0.5.2
-    compconPrereleaseSuffix: 
+    compconPrereleaseSuffix: issue123 
     imagePullPolicy: IfNotPresent
     istioGateway: true
     secconImage: tmforumodacanvas/security-listener
@@ -259,6 +259,6 @@ secretsmanagement-operator:
 oda-webhook:
   image: tmforumodacanvas/compcrdwebhook
   version: 0.8.2
-  prereleaseSuffix:
+  prereleaseSuffix: issue123
   imagePullPolicy: IfNotPresent
 

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -113,7 +113,7 @@ controller:
     controllerName: oda-controller
     compconImage: tmforumodacanvas/component-istio-controller
     compconVersion: 0.5.2
-    compconPrereleaseSuffix:  
+    compconPrereleaseSuffix: 
     imagePullPolicy: IfNotPresent
     istioGateway: true
     secconImage: tmforumodacanvas/security-listener


### PR DESCRIPTION
As discussed in the clinic session yesterday, the execution of the BDD tests in a PR should be skipped, if in step 5 of the process described in [work-with-dockerimages.md](https://github.com/tmforum-oda/oda-canvas/blob/master/docs/developer/work-with-dockerimages.md#tldr) the prerelease suffixes are removed in the charts/canvas-oda/values.yaml file.

The current process step describes to add the magic words "[skip tests]" to the commit message. @brian-burton proposed another solution, to automatically detect, if a commit only removes these prereleaseSuffix values. This PR adds this check.

There already exists a check for skip tests job. This job is now extended by a new check which does the following:

* get the list of changed files of the last git commit
* if not only charts/canvas-oda/values.yaml was changed -> do not skip tests
* check the diff for the changes (ignoring whitespace):
  * only lines were changed to empty prereleaseSuffix values -> skip tests




