### PR TITLE
Issue 381 - Bring your own Cert for Component Gateway

### DIFF
--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.8-rc1
+version: 1.1.8-rc2
+# version: 1.1.8-rc2 - make hostname and cert configurable for component gateway
 # version: 1.1.8-rc1 - fix linux/arm64 docker build for secretsmanagement-operator
 # version: 1.1.7     - updated to v1beta4 crds
 # version: 1.1.6     - updated kong and apisix installation to change istio-ingress behaviour , ssl enabled on istio-ingress for api-gateway, updated component crds,added test to check latest chart once helm charts are published on github
@@ -59,7 +60,7 @@ dependencies:
     repository: 'https://charts.bitnami.com/bitnami'
     condition: keycloak.enabled
   - name: controller
-    version: "1.1.3"
+    version: "1.1.4"
     repository: 'file://../controller'
   - name: dependentapi-simple-operator
     version: "0.2.3"

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -132,6 +132,9 @@ controller:
     keycloak: *portKeycloak
     dataDog:
       enabled: true
+    hostName: "*"
+    httpsRedirect: true
+    credentialName: istio-ingress-cert    
   #We reuse the admin user created on keycloak installation
   credentials:
     user: admin

--- a/charts/controller/Chart.yaml
+++ b/charts/controller/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
+# version: 1.1.4 - make hostname and cert configurable for component gateway
 # version: 1.1.3 - updated docker image for controller to tmforumodacanvas/component-controller:0.5.6
 # version: 1.1.2 - updated rbac for clusterrole of api gateways 
 # version: 1.1.1 - issue #302: remove "-dapi-" infix from dependent api custom resource name

--- a/charts/controller/templates/ingressGateway.yaml
+++ b/charts/controller/templates/ingressGateway.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "5"
     "helm.sh/resource-policy": keep
   name: component-gateway

--- a/charts/controller/templates/ingressGateway.yaml
+++ b/charts/controller/templates/ingressGateway.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "5"
     "helm.sh/resource-policy": keep
   name: component-gateway

--- a/charts/controller/templates/ingressGateway.yaml
+++ b/charts/controller/templates/ingressGateway.yaml
@@ -19,16 +19,16 @@ spec:
       name: http
       protocol: HTTP
     tls:
-      httpsRedirect: true
+      httpsRedirect: {{ .Values.deployment.httpsRedirect }}
     hosts:
-    - "*"
+    - "{{ .Values.deployment.hostName }}"
   - port:
       number: 443
       name: https
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: istio-ingress-cert  
+      credentialName: {{ .Values.deployment.credentialName }}  
     hosts:
-    - "*"
+    - "{{ .Values.deployment.hostName }}"
 {{ end }}

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -17,6 +17,9 @@ deployment:
     enabled: false
   keycloak:
     port: 8080
+  hostName: "*"
+  httpsRedirect: true
+  credentialName: istio-ingress-cert    
 #We reuse the admin user created on keycloak instalation
 credentials:
   user: admin


### PR DESCRIPTION
As mentioned in issue #381 the hardcoded values for hostName ("*"), httpsRedirect (true) and credentialsName (istio-ingress-cert) are extracted from the ingressGateway.yaml into the values.yaml.
There they can be overwritten by need.
The defaultvalues are identical to the hardcoded values, so this refactoring does not change any existing behavior.
