### PR TITLE
add config for publicHostname to api-operator values.yaml

### DIFF
--- a/charts/api-operator-istio/templates/configMap.yaml
+++ b/charts/api-operator-istio/templates/configMap.yaml
@@ -14,3 +14,6 @@ data:
   {{- if .Values.deployment.dataDog.enabled }}
   OPENMETRICS_IMPLEMENTATION: "DataDogAnnotation"
   {{ end }}
+  {{- if .Values.configmap.publicHostname }}
+  APIOPERATORISTIO_PUBLICHOSTNAME: {{ .Values.configmap.publicHostname }}
+  {{ end }}

--- a/charts/api-operator-istio/values.yaml
+++ b/charts/api-operator-istio/values.yaml
@@ -18,3 +18,4 @@ deployment:
   credentialName: istio-ingress-cert    
 configmap:
   loglevel: '20'
+  # publicHostname: 'components.example.com'

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -159,6 +159,7 @@ api-operator-istio:
     credentialName: istio-ingress-cert    
   configmap:
     loglevel: '20'
+    # publicHostname: 'components.example.com'
      
 dependentapi-simple-operator:
   enabled: true


### PR DESCRIPTION
allows configuring the public hostname to be used as domain name in api-operator-istio.