### PR TITLE
[Feature][Proposal] API Optionality Definition

### DIFF
--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -1525,9 +1525,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are exposed by the API.
+                        #required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not. required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -1559,9 +1560,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are consumed by the API.
+                        #required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not. required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -1768,9 +1770,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are exposed by the API.
+                        #required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not. required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -1802,9 +1805,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are consumed by the API.
+                        # required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not. required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -1972,9 +1976,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are exposed by the API.
+                        # required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not.required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -2006,9 +2011,10 @@ spec:
                           items:
                             type: object
                           description: Resources is an optional list of resources that are consumed by the API.
+                        # required attribute can be ignored when conformance is specified.
                         required:
                           type: boolean
-                          description: Required is a flag that indicates whether the API is required or not.
+                          description: Required is a flag that indicates whether the API is required or not. required attribute can be ignored when conformance is specified.
                       required:
                       - name
                       - apiType
@@ -2034,7 +2040,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2070,7 +2083,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2108,7 +2128,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2149,7 +2176,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2185,7 +2219,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2223,7 +2264,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2267,7 +2315,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2303,7 +2358,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2341,7 +2403,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2382,7 +2451,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2418,7 +2494,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2456,7 +2539,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2500,7 +2590,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2536,7 +2633,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2574,7 +2678,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2615,7 +2726,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2651,7 +2769,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2689,7 +2814,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2733,7 +2865,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2769,7 +2908,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2807,7 +2953,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2848,7 +3001,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:
@@ -2884,7 +3044,14 @@ spec:
                           properties:
                             name:
                               type: string
-                              description: refer to a name in apis collection
+                              description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                            conformanceProfile:
+                              type: object
+                              description: defines the external conformance conformanceProfile
+                              properties:
+                                profileLink:
+                                  type: string
+                                  description: specifies the location where the profile can be found.
                             conformanceLevel:
                               type: string
                               enum:
@@ -2922,7 +3089,14 @@ spec:
                             properties:
                               name:
                                 type: string
-                                description: refer to a name in apis collection
+                                description: refer to a 'name' attribute value of API definition in corresponding entity of this in spec section.
+                              conformanceProfile:
+                                type: object
+                                description: defines the external conformance conformanceProfile
+                                properties:
+                                  profileLink:
+                                    type: string
+                                    description: specifies the location where the profile can be found.
                               conformanceLevel:
                                 type: string
                                 enum:

--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -2016,6 +2016,941 @@ spec:
                     description: This is the name of the role that the Canvas controllers will use to interact with the component's APIs.
                       It must exist in the roles exposed by the partyRole API.
                     type: string
+          conformance:
+            type: object
+            properties:
+              coreFunction:
+                type: object
+                properties:
+                  exposedAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                  dependentAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+              managementFunction:
+                type: object
+                properties:
+                  exposedAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                  dependentAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+              securityFunction:
+                type: object
+                properties:
+                  exposedAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                  dependentAPIs:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+              eventNotification:
+                type: object
+                properties:
+                  publishedEvents:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                  subscribedEvents:
+                    type: object
+                    properties:
+                      requiredOneOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
+                      requiredAllOf:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: refer to a name in apis collection
+                            conformanceLevel:
+                              type: string
+                              enum:
+                              - L1
+                              - L2
+                            additionalResourceConformance:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  resource:
+                                    type: string
+                                  methods:
+                                    type: array
+                                    items:
+                                      type: string
+                                  parameters:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        paramPath:
+                                          type: string
+                                          description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                      required:
+                                      - paramPath                              
+                          required:
+                          - name
+                      requiredAnyOf:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                                description: refer to a name in apis collection
+                              conformanceLevel:
+                                type: string
+                                enum:
+                                - L1
+                                - L2
+                              additionalResourceConformance:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                      resource:
+                                        type: string
+                                      methods:
+                                        type: array
+                                        items:
+                                          type: string
+                                      parameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            paramPath:
+                                              type: string
+                                              description: path follows JsonPath standards, https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html, https://ietf-wg-jsonpath.github.io/draft-ietf-jsonpath-base/draft-ietf-jsonpath-base.html
+                                          required:
+                                          - paramPath
+                            required:
+                            - name
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
 This change proposes a conformance model which allows to define the optionality of the APIs given in the spec section.
Some example use cases :

1. The component TMFC006-Service Catalog Management has 2 mandatory Exposed APIs in its Core Functions {TMF633 Service Catalog Management, TMF657 Service Quality Management}. So those can be defined as below:

```
conformance:
  coreFunction:
    exposedAPIs:
      requiredAllOf: 
      - name: TMF633
      - name: TMF657
```

2. The component Component TMFC006-Service Catalog Management can expose two versions of the same APIs,

-  - TMF633 Service Catalog Management v4
   - TMF657 Service Quality Management v4


-  - TMF633 Service Catalog Management v5
    - TMF657 Service Quality Management v5 

Those can be defined as below:

```
conformance:
  coreFunction:
    exposedAPIs:
      requiredOneOf: 
      - - name: TMF633_v4
        - name: TMF657_v4
      - - name: TMF633_v5
        - name: TMF657_v5
```


3. The component TMFC002-Product Order Capture and Validation has 2 mandatory Dependent APIs in its Core Functions {TMF620 Product Catalog Management, TMF637 Product Inventory Management}. So those can be defined as below:

```
conformance:
  coreFunction:
    dependentAPIs:
      requiredAllOf: 
      - name: TMF620
      - name: TMF637
```

4. The component TMFC001-Product Catalog Dependent APIs are all optional in its Core Functions. It's integrated with {TMF620 Product Catalog Management, TMF669 Party Role Management}. So those can be defined as below:

```
conformance:
  coreFunction:
    dependentAPIs:
      requiredAnyOf: 
      - - name: TMF620
        -  name: TMF669
```

The `conformanceProfile` refers to an external location where conformance profile details are stored. It can be used if L1( out of the box conformance profile) or L2 (supported ODA extended conformance) is not sufficient.