### PR TITLE
Templatize Hardcoded Images in Post/Pre-Install/Upgrade Hook Jobs

### DIFF
--- a/charts/api-operator-istio/Chart.yaml
+++ b/charts/api-operator-istio/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
+# version: 1.1.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.4 - added job to avoid istio-ingress to patch as Loadbalancer if present in any other type
 # version: 1.0.3 - minor bugfixes

--- a/charts/api-operator-istio/templates/EnableIstioLB.yaml
+++ b/charts/api-operator-istio/templates/EnableIstioLB.yaml
@@ -11,7 +11,7 @@ spec:
       serviceAccountName: apioperator-account
       containers:
       - name: patch-istio-ingress
-        image: bitnami/kubectl:latest  # Using kubectl image
+        image: {{ .Values.global.hookImages.kubectl }}  # Using kubectl image
         command:
           - /bin/sh
           - -c

--- a/charts/apisix-gateway/Chart.yaml
+++ b/charts/apisix-gateway/Chart.yaml
@@ -15,8 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
-
+version: 1.0.1
+# version: 1.0.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds
 # version: 0.1.3 - chart bundled with canvas-oda chart and job added to handle required istio-ingress type

--- a/charts/apisix-gateway/templates/DisableIstioLB.yaml
+++ b/charts/apisix-gateway/templates/DisableIstioLB.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-operator
       containers:
       - name: patch-istio-ingress
-        image: bitnami/kubectl:latest
+        image: {{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -16,7 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.2.0
+version: 1.2.1
+# version: 1.2.1     - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.2.0     - initial release of v1 component specification
 # version: 1.1.8     - released version
 # version: 1.1.8-lt6 - final changes to v1beta4 crd

--- a/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
+++ b/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccountName: odacomponent-account
       containers:
         - name: component-checker
-          image: bitnami/kubectl:latest
+          image: {{- .Values.global.hookImages.kubectl }}
           command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/templates/prehook.yaml
+++ b/charts/canvas-oda/templates/prehook.yaml
@@ -13,7 +13,7 @@ spec:
       serviceAccount: canvas-sm-prehook-sa
       containers:
       - name: check-istio
-        image: bitnami/kubectl:latest
+        image: {{ .Values.global.hookImages.kubectl }}
         command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -8,6 +8,12 @@ global:
   certificate:
     # -- Name of the certificate and webhook |
     appName: "compcrdwebhook"
+  
+  # Images used in post/pre-install/upgrade hook jobs
+  hookImages:
+    kubectl: bitnami/kubectl:latest
+    kubectlCurl: tmforumodacanvas/baseimage-kubectl-curl:1.30.5
+    busybox: busybox:1.35
 
 preqrequisitechecks:
   istio:  true 

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
+# version: 1.0.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.2.1 - issue 372 - deploy non-DEV Vault with persistence and autounseal 
 # version: 0.2.0 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 

--- a/charts/canvas-vault/templates/autounseal-cronjob.yaml
+++ b/charts/canvas-vault/templates/autounseal-cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           containers:
           - name: autounsealvault
             # TODO[FH] remove suffix before merging to master/main
-            image: tmforumodacanvas/baseimage-kubectl-curl:1.30.5
+            image: {{ .Values.global.hookImages.kubectlCurl }}
             imagePullPolicy: IfNotPresent
             env:
             - name: VAULT_ADDR

--- a/charts/canvas-vault/templates/post-install-hook.yaml
+++ b/charts/canvas-vault/templates/post-install-hook.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: post-install-job
         # TODO[FH] remove suffix before merging to master/main
-        image: tmforumodacanvas/baseimage-kubectl-curl:1.30.5
+        image: {{ .Values.global.hookImages.kubectl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting canvas vault post install hook;

--- a/charts/cert-manager-init/Chart.yaml
+++ b/charts/cert-manager-init/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
+# version: 1.1.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.2 - updated appVersion to v1beta4
 # version: 1.0.1 - added cert for istio-ingress to enable ssl

--- a/charts/cert-manager-init/templates/webhook.yaml
+++ b/charts/cert-manager-init/templates/webhook.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: post-install
-          image: busybox:1.35
+          image: {{ .Values.global.hookImages.busybox }}
           imagePullPolicy: IfNotPresent
           command: ['sleep', '{{- $delay}}']
       restartPolicy: OnFailure

--- a/charts/dependentapi-simple-operator/Chart.yaml
+++ b/charts/dependentapi-simple-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
+# version: 1.0.1 - Templatize hardcoded image of mongodb in mongodb deployment
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.3.0 - issue 414 - Updated structure of specification url in dependentApi resource
 # version: 0.2.4 - issue 320 - DependentAPI-Simple-Operator supports Canvas Log Viewer format

--- a/charts/dependentapi-simple-operator/templates/serviceinventoryapi-mongodb-deployment.yaml
+++ b/charts/dependentapi-simple-operator/templates/serviceinventoryapi-mongodb-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: {{.Release.Name}}-svcinv-mongodb
-        image: mongo:6.0
+        image: {{ .Values.serviceInventoryAPI.mongodb.image }}
         ports:
         - name: svcinv-mongodb
           containerPort: {{.Values.serviceInventoryAPI.mongodb.port}}

--- a/charts/dependentapi-simple-operator/values.yaml
+++ b/charts/dependentapi-simple-operator/values.yaml
@@ -13,4 +13,5 @@ serviceInventoryAPI:
   serverUrl: http://info.canvas.svc.cluster.local
   mongodb:
     port: 27017
-    database: svcinv 
+    database: svcinv
+    image: mongo:6.0

--- a/charts/kong-gateway/Chart.yaml
+++ b/charts/kong-gateway/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
+# version: 1.0.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds
 # version: 0.1.3 - chart bundled with canvas-oda chart and job added to handle required istio-ingress type

--- a/charts/kong-gateway/templates/DisableIstioLB.yaml
+++ b/charts/kong-gateway/templates/DisableIstioLB.yaml
@@ -12,7 +12,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-operator
       containers:
       - name: patch-istio-ingress
-        image: bitnami/kubectl:latest
+        image: {{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/secretsmanagement-operator/Chart.yaml
+++ b/charts/secretsmanagement-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
+# version: 1.0.1 - Templatize hardcoded images in post/pre-install/upgrade hook jobs
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.3 - issue 320 - SecretsManagemnt-Operator supports Canvas Log Viewer format 
 # version: 0.1.2 - allow https calls to Vault with self-signed certs (VAULT_SKIP_VERIFY env var)

--- a/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
+++ b/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
       - name: autodetect-audience
         # TODO[FH]: remove prereleasesuffix
-        image: "tmforumodacanvas/baseimage-kubectl-curl:1.30.5"
+        image: {{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting autodetect audience pre install hook;


### PR DESCRIPTION
This pull request addresses the issue of hardcoded container image references in post/pre-install/upgrade hook jobs in canvas operator's helm charts, this allows helm charts to be more configurable.

**Changes**:
- Replaced hardcoded image references in hook jobs with templated values.
- Introduced new keys in global values of canvas-oda helm chart for hook images.
 