### PR TITLE
Support Custom/Private Docker Registry and Image Pull Secrets

### DIFF
--- a/charts/api-operator-istio/Chart.yaml
+++ b/charts/api-operator-istio/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
+# version: 1.1.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.1 - Templatized hardcoded images
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.4 - added job to avoid istio-ingress to patch as Loadbalancer if present in any other type

--- a/charts/api-operator-istio/templates/EnableIstioLB.yaml
+++ b/charts/api-operator-istio/templates/EnableIstioLB.yaml
@@ -9,9 +9,13 @@ spec:
   template:
     spec:
       serviceAccountName: apioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}  # Using kubectl image
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}  # Using kubectl image
         command:
           - /bin/sh
           - -c

--- a/charts/api-operator-istio/templates/_helpers.tpl
+++ b/charts/api-operator-istio/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full apiop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "api-operator-istio.apiopDockerimage" -}}
-  {{- .Values.deployment.apiopImage -}}:{{- .Values.deployment.apiopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.apiopImage -}}:{{- .Values.deployment.apiopVersion -}}
   {{- if .Values.deployment.apiopPrereleaseSuffix -}}
     -{{- .Values.deployment.apiopPrereleaseSuffix -}}
   {{- end -}}
@@ -82,4 +82,3 @@ overwrite apiop imagePullSecret with "Always" if prereleaseSuffix is set
     {{- .Values.deployment.apiopImagePullPolicy -}}
   {{- end -}}
 {{- end -}}
-

--- a/charts/api-operator-istio/templates/deployment.yaml
+++ b/charts/api-operator-istio/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "api-operator-istio.labels" . | nindent 8 }}
     spec:
       serviceAccountName: apioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "api-operator-istio.apiopDockerimage" . }}

--- a/charts/apisix-gateway/Chart.yaml
+++ b/charts/apisix-gateway/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/apisix-gateway/templates/Deployment.yaml
+++ b/charts/apisix-gateway/templates/Deployment.yaml
@@ -14,9 +14,13 @@ spec:
         app: {{ .Release.Name }}-apisixistio-operator
     spec:
       serviceAccountName: apisixapioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       initContainers:
         - name: wait-apisix-admin
-          image: {{ .Values.initContainerImage }}
+          image: {{ include "docker.registry" .}}{{ .Values.initContainerImage }}
           command:
             - sh
             - -c
@@ -24,5 +28,5 @@ spec:
               until nc -z canvas-apisix-admin.canvas.svc.cluster.local 9180; do echo waiting for canvas-apisix-admin; sleep 2; done;
       containers:
       - name: {{ .Release.Name }}-apisixistio-operator
-        image: {{ .Values.apisixoperatorimage.repository }}
+        image: {{ include "docker.registry" .}}{{ .Values.apisixoperatorimage.repository }}
         imagePullPolicy: {{ .Values.apisixoperatorimage.pullPolicy }}

--- a/charts/apisix-gateway/templates/DisableIstioLB.yaml
+++ b/charts/apisix-gateway/templates/DisableIstioLB.yaml
@@ -10,9 +10,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -58,7 +58,7 @@ appVersion: "v1"
 
 dependencies:
   - name: cert-manager-init
-    version: "1.1.1"
+    version: "1.1.2"
     repository: 'file://../cert-manager-init'
   - name: canvas-namespaces
     version: "1.0.1"
@@ -73,34 +73,34 @@ dependencies:
     repository: 'https://charts.bitnami.com/bitnami'
     condition: keycloak.enabled
   - name: component-operator
-    version: "1.3.0"
+    version: "1.3.1"
     repository: 'file://../component-operator'
   - name: identityconfig-operator-keycloak
-    version: "1.2.0"
+    version: "1.2.1"
     repository: 'file://../identityconfig-operator-keycloak'  
   - name: api-operator-istio
-    version: "1.1.1"
+    version: "1.1.2"
     repository: 'file://../api-operator-istio'
     condition: api-operator-istio.enabled
   - name: dependentapi-simple-operator
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../dependentapi-simple-operator'
     condition: dependentapi-simple-operator.enabled
   - name: secretsmanagement-operator
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../secretsmanagement-operator'
   - name: canvas-vault
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../canvas-vault'
     condition: canvas-vault.enabled
   - name: oda-webhook
-    version: "1.2.0"
+    version: "1.2.1"
     repository: 'file://../oda-webhook'
   - name: kong-gateway
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../kong-gateway'
     condition: kong-gateway-install.enabled
   - name: apisix-gateway
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../apisix-gateway'
     condition: apisix-gateway-install.enabled

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -16,7 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.2.1-rc1
+version: 1.2.1-rc2
+# version: 1.2.1-rc2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.1-rc1 - Templatized hardcoded images
 # version: 1.2.0     - initial release of v1 component specification
 # version: 1.1.8     - released version

--- a/charts/canvas-oda/templates/_helpers.tpl
+++ b/charts/canvas-oda/templates/_helpers.tpl
@@ -60,3 +60,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Custom/private docker image registry
+*/}}
+{{- define "docker.registry" -}}
+{{- if .Values.global.image.registry }}
+{{- $registry := (trimSuffix "/" .Values.global.image.registry) }}
+{{- printf "%s/" $registry }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create image pull secrets
+*/}}
+{{- define "image-pull-secrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
+++ b/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
@@ -11,9 +11,13 @@ spec:
   template:
     spec:
       serviceAccountName: odacomponent-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
         - name: component-checker
-          image: {{ .Values.global.hookImages.kubectl }}
+          image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
           command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/templates/prehook.yaml
+++ b/charts/canvas-oda/templates/prehook.yaml
@@ -11,9 +11,13 @@ spec:
   template:
     spec:
       serviceAccount: canvas-sm-prehook-sa
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: check-istio
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -5,6 +5,16 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 global:
+  image:
+    # docker registry to pull images from
+    registry: ""
+  
+  # image pull secret to pull images from private registry
+  imagePullSecrets: []
+  # imagePullSecrts:
+  # - imagepullsecret1
+  # - imagepullsecret2
+
   certificate:
     # -- Name of the certificate and webhook |
     appName: "compcrdwebhook"

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.2.1 - issue 372 - deploy non-DEV Vault with persistence and autounseal 

--- a/charts/canvas-vault/templates/autounseal-cronjob.yaml
+++ b/charts/canvas-vault/templates/autounseal-cronjob.yaml
@@ -13,10 +13,14 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          {{- if .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+          {{- include "image-pull-secrets" . |nindent 10 }}
+          {{- end }}
           containers:
           - name: autounsealvault
             # TODO[FH] remove suffix before merging to master/main
-            image: {{ .Values.global.hookImages.kubectlCurl }}
+            image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
             imagePullPolicy: IfNotPresent
             env:
             - name: VAULT_ADDR

--- a/charts/canvas-vault/templates/post-install-hook.yaml
+++ b/charts/canvas-vault/templates/post-install-hook.yaml
@@ -23,11 +23,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: post-install-job
         # TODO[FH] remove suffix before merging to master/main
-        image: {{ .Values.global.hookImages.kubectlCurl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting canvas vault post install hook;

--- a/charts/cert-manager-init/Chart.yaml
+++ b/charts/cert-manager-init/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
+# version: 1.1.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.1 - Templatized hardcoded images
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.2 - updated appVersion to v1beta4

--- a/charts/cert-manager-init/templates/webhook.yaml
+++ b/charts/cert-manager-init/templates/webhook.yaml
@@ -15,9 +15,13 @@ metadata:
 spec:
   template:
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
         - name: post-install
-          image: {{ .Values.global.hookImages.busybox }}
+          image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.busybox }}
           imagePullPolicy: IfNotPresent
           command: ['sleep', '{{- $delay}}']
       restartPolicy: OnFailure

--- a/charts/component-operator/Chart.yaml
+++ b/charts/component-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
+# version: 1.3.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.3.0 - updated to use v1 of CRD spec
 # version: 1.2.2 - changed seccon user to canvassystem and keycloak realm to odari
 # version: 1.2.1 - removed operator-command configMap - no longer using entrypoint.sh

--- a/charts/component-operator/templates/_helpers.tpl
+++ b/charts/component-operator/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full compop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "component-operator.compopDockerimage" -}}
-  {{- .Values.deployment.compopImage -}}:{{- .Values.deployment.compopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.compopImage -}}:{{- .Values.deployment.compopVersion -}}
   {{- if .Values.deployment.compopPrereleaseSuffix -}}
     -{{- .Values.deployment.compopPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/component-operator/templates/deployment.yaml
+++ b/charts/component-operator/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "component-operator.labels" . | nindent 8 }}
     spec:
       serviceAccountName: odacomponent-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "component-operator.compopDockerimage" . }}

--- a/charts/dependentapi-simple-operator/Chart.yaml
+++ b/charts/dependentapi-simple-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.3.0 - issue 414 - Updated structure of specification url in dependentApi resource

--- a/charts/dependentapi-simple-operator/templates/_helpers.tpl
+++ b/charts/dependentapi-simple-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full dependent api docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "dependentapi-simple-operator.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}
@@ -25,7 +25,7 @@ overwrite imagePullSecret with "Always" if prereleaseSuffix is set
 build the full dependent api docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "dependentapi-serviceinventoryapi.dockerimage" -}}
-  {{- .Values.serviceInventoryAPI.image -}}:{{- .Values.serviceInventoryAPI.version -}}
+  {{ include "docker.registry" .}}{{- .Values.serviceInventoryAPI.image -}}:{{- .Values.serviceInventoryAPI.version -}}
   {{- if .Values.serviceInventoryAPI.prereleaseSuffix -}}
     -{{- .Values.serviceInventoryAPI.prereleaseSuffix -}}
   {{- end -}}

--- a/charts/dependentapi-simple-operator/templates/depapi-operator-deployment.yaml
+++ b/charts/dependentapi-simple-operator/templates/depapi-operator-deployment.yaml
@@ -15,6 +15,10 @@ spec:
         app: {{ .Release.Name }}-depapi-op
     spec:
       serviceAccountName: {{ .Release.Name }}-depapi-op-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-depapi-op
         image: {{ include "dependentapi-simple-operator.dockerimage" . }}

--- a/charts/dependentapi-simple-operator/templates/serviceinventoryapi-deployment.yaml
+++ b/charts/dependentapi-simple-operator/templates/serviceinventoryapi-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-info-service
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-info-service
         image: {{ include "dependentapi-serviceinventoryapi.dockerimage" . }}

--- a/charts/dependentapi-simple-operator/templates/serviceinventoryapi-mongodb-deployment.yaml
+++ b/charts/dependentapi-simple-operator/templates/serviceinventoryapi-mongodb-deployment.yaml
@@ -15,9 +15,13 @@ spec:
       labels:
         app: {{.Release.Name}}-svcinv-mongodb
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Release.Name}}-svcinv-mongodb
-        image: {{ .Values.serviceInventoryAPI.mongodb.image }}
+        image: {{ include "docker.registry" .}}{{ .Values.serviceInventoryAPI.mongodb.image }}
         ports:
         - name: svcinv-mongodb
           containerPort: {{.Values.serviceInventoryAPI.mongodb.port}}

--- a/charts/identityconfig-operator-keycloak/Chart.yaml
+++ b/charts/identityconfig-operator-keycloak/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
+# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to use v1 of CRD spec
 # version: 1.1.0 - changed controllerRole to canvasSystemRole
 # version: 1.0.0 - initial version - identityconfig separated out from component operator

--- a/charts/identityconfig-operator-keycloak/templates/_helpers.tpl
+++ b/charts/identityconfig-operator-keycloak/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full idkop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "identityconfig-operator-keycloak.idkopImage" -}}
-  {{- .Values.deployment.idkopImage -}}:{{- .Values.deployment.idkopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.idkopImage -}}:{{- .Values.deployment.idkopVersion -}}
   {{- if .Values.deployment.idkopPrereleaseSuffix -}}
     -{{- .Values.deployment.idkopPrereleaseSuffix -}}
   {{- end -}}
@@ -76,7 +76,7 @@ build the full idkop docker image name from image + version + prereleaseSuffix
 build the full idlistkey docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "identityconfig-operator-keycloak.idlistkeyImage" -}}
-  {{- .Values.deployment.idlistkeyImage -}}:{{- .Values.deployment.idlistkeyVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.idlistkeyImage -}}:{{- .Values.deployment.idlistkeyVersion -}}
   {{- if .Values.deployment.idlistkeyPrereleaseSuffix -}}
     -{{- .Values.deployment.idlistkeyPrereleaseSuffix -}}
   {{- end -}}
@@ -93,6 +93,3 @@ overwrite idkop imagePullSecret with "Always" if prereleaseSuffix is set
     {{- .Values.deployment.imagePullPolicy -}}
   {{- end -}}
 {{- end -}}
-
-
-

--- a/charts/identityconfig-operator-keycloak/templates/deployment.yaml
+++ b/charts/identityconfig-operator-keycloak/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "identityconfig-operator-keycloak.labels" . | nindent 8 }}
     spec:
       serviceAccountName: identityconfig-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "identityconfig-operator-keycloak.idkopImage" . }}

--- a/charts/kong-gateway/Chart.yaml
+++ b/charts/kong-gateway/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/kong-gateway/templates/Deployment.yaml
+++ b/charts/kong-gateway/templates/Deployment.yaml
@@ -14,9 +14,13 @@ spec:
         app: {{ .Release.Name }}-kongistio-operator
     spec:
       serviceAccountName: kongapioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       initContainers:
         - name: wait-kong-admin
-          image: {{ .Values.initContainerImage }}
+          image: {{ include "docker.registry" .}}{{ .Values.initContainerImage }}
           command:
             - sh
             - -c
@@ -24,5 +28,5 @@ spec:
               until nc -z canvas-kong-admin.kong.svc.cluster.local 8001; do echo waiting for kong-admin; sleep 2; done;
       containers:
       - name: {{ .Release.Name }}-kongistio-operator
-        image: {{ .Values.kongoperatorimage.repository }}
+        image: {{ include "docker.registry" .}}{{ .Values.kongoperatorimage.repository }}
         imagePullPolicy: {{ .Values.kongoperatorimage.pullPolicy }}

--- a/charts/kong-gateway/templates/DisableIstioLB.yaml
+++ b/charts/kong-gateway/templates/DisableIstioLB.yaml
@@ -10,9 +10,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/oda-webhook/Chart.yaml
+++ b/charts/oda-webhook/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
+# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to support v1 of CRD spec (and remove v1beta1)
 # version: 1.1.4 - added componentMetadata and apiSDO to v1beta4 crds
 # version: 1.1.3 - added v1beta4 crds and removed v1alpha crds

--- a/charts/oda-webhook/templates/_helpers.tpl
+++ b/charts/oda-webhook/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full oda-webhook docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "oda-webhook.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}

--- a/charts/oda-webhook/templates/deployment-componentcrdwebhook.yaml
+++ b/charts/oda-webhook/templates/deployment-componentcrdwebhook.yaml
@@ -16,6 +16,10 @@ spec:
         app: compcrdwebhook 
         {{- include "oda-webhook.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: compcrdwebhook 
         image: {{ include "oda-webhook.dockerimage" . }}

--- a/charts/secretsmanagement-operator/Chart.yaml
+++ b/charts/secretsmanagement-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.3 - issue 320 - SecretsManagemnt-Operator supports Canvas Log Viewer format 

--- a/charts/secretsmanagement-operator/templates/_helpers.tpl
+++ b/charts/secretsmanagement-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "secretsmanagementoperator.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}
@@ -13,7 +13,7 @@ build the full docker image name from image + version + prereleaseSuffix
 build the full sidecar docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "secretsmanagementoperator.sidecarDockerimage" -}}
-  {{- .Values.sidecarImage -}}:{{- .Values.sidecarVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.sidecarImage -}}:{{- .Values.sidecarVersion -}}
   {{- if .Values.sidecarPrereleaseSuffix -}}
     -{{- .Values.sidecarPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
+++ b/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
@@ -24,11 +24,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: autodetect-audience
         # TODO[FH]: remove prereleasesuffix
-        image: {{ .Values.global.hookImages.kubectlCurl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting autodetect audience pre install hook;

--- a/charts/secretsmanagement-operator/templates/smanop-deployment.yaml
+++ b/charts/secretsmanagement-operator/templates/smanop-deployment.yaml
@@ -15,6 +15,10 @@ spec:
         app: {{ .Release.Name }}-smanop
     spec:
       serviceAccountName: {{ .Release.Name }}-smanop-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-smanop
         image: {{ include "secretsmanagementoperator.dockerimage" . }}


### PR DESCRIPTION
**Summary**
This PR introduces support for configuring a custom or private Docker registry and image pull secrets in the Helm charts. These changes enhance the flexibility and usability of the charts, especially for environments requiring custom registries/private docker registries or authentication for pulling images from those custom/private docker registries.

**Changes**
- Added `global.image.registry` to `canvas-oda` helm chart's values.yaml for specifying a custom/private Docker registry.
- Introduced `global.imagePullSecrets` in `canvas-oda` helm chart's values.yaml to configure image pull secrets for authenticating with private registries.
- Updated all image references in all charts templates to prepend the `global.image.registry` value.
- Modified templates to include imagePullSecrets when defined.

ISSUE - #444 
