### PR TITLE
[skip tests] update Canvas-Log-Viewer to support new and renamed operators

### DIFF
--- a/source/utilities/canvas-log-viewer/python_alternative/README.md
+++ b/source/utilities/canvas-log-viewer/python_alternative/README.md
@@ -43,7 +43,7 @@ sudo ln -s ~/canvaslogs/kubectl-canvaslogs /usr/local/bin/kubectl-canvaslogs
 $ kubectl canvaslogs
 
 
-usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio) [<componentfilter>] [-l <last-hours>]
+usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio|idconf|credman) [<componentfilter>] [-l <last-hours>]
        needs python with 'pip install rich timedinput'
 
 options:

--- a/source/utilities/canvas-log-viewer/python_alternative/kubectl-canvaslogs
+++ b/source/utilities/canvas-log-viewer/python_alternative/kubectl-canvaslogs
@@ -29,16 +29,22 @@ then
     kubectl logs -n canvas deployment/component-operator -c component-operator $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
 elif [ "$OPERATOR" = "sman" ]
 then
-    kubectl logs -n canvas deployment/secretsmanagement-operator-vault $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
+    kubectl logs -n canvas deployment/canvas-smanop $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
 elif [ "$OPERATOR" = "depapi" ]
 then
-    kubectl logs -n canvas deployment/dependent-api-simple-operator $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
+    kubectl logs -n canvas deployment/canvas-depapi-op $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
 elif [ "$OPERATOR" = "apiistio" ]
 then
     kubectl logs -n canvas deployment/api-operator-istio $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
+elif [ "$OPERATOR" = "idconf" ]
+then
+    kubectl logs -n canvas deployment/identityconfig-operator-keycloak $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
+elif [ "$OPERATOR" = "credman" ]
+then
+    kubectl logs -n canvas deployment/credentialsmanagement-operator $FOLLOW | $PYTHON $CANVASLOGS_FOLDER/showlogtree.py $COMP_PATTERN $FOLLOW $1 $2 $3 $4 $5 $6 $7 $8 $9
 else
     echo ""
-    echo "usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio) [<componentfilter>] [-l <last-hours>]"
+    echo "usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio|idconf|credman) [<componentfilter>] [-l <last-hours>]"
     echo "       needs python with 'pip install rich timedinput'"
     echo ""
     echo "options:"

--- a/source/utilities/canvas-log-viewer/python_alternative/kubectl-canvaslogs.cmd
+++ b/source/utilities/canvas-log-viewer/python_alternative/kubectl-canvaslogs.cmd
@@ -29,20 +29,28 @@ if "%OPERATOR%" == "comp" (
 	GOTO :eof
 )
 if "%OPERATOR%" == "sman" (
-	kubectl logs -n canvas deployment/secretsmanagement-operator-vault %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
+	kubectl logs -n canvas deployment/canvas-smanop %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
 	GOTO :eof
 )
 if "%OPERATOR%" == "depapi" (
-	kubectl logs -n canvas deployment/dependent-api-simple-operator %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
+	kubectl logs -n canvas deployment/canvas-depapi-op %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
 	GOTO :eof
 )
 if "%OPERATOR%" == "apiistio" (
 	kubectl logs -n canvas deployment/api-operator-istio %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
 	GOTO :eof
 )
+if "%OPERATOR%" == "idconf" (
+	kubectl logs -n canvas deployment/identityconfig-operator-keycloak %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
+	GOTO :eof
+)
+if "%OPERATOR%" == "credman" (
+	kubectl logs -n canvas deployment/credentialsmanagement-operator %FOLLOW% | %PYTHON% %CANVASLOGS_FOLDER%\showlogtree.py %COMP_PATTERN% %FOLLOW% %1 %2 %3 %4 %5 %6 %7 %8 %9
+	GOTO :eof
+)
 
 echo "                                                                                                "
-echo "usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio) [<componentfilter>] [-l <last-hours>]"
+echo "usage: kubectl canvaslogs [-f] (comp|sman|depapi|apiistio|idconf|credman) [<componentfilter>] [-l <last-hours>]"
 echo "       needs python with 'pip install rich timedinput'                                          "
 echo "                                                                                                "
 echo "options:                                                                                        "


### PR DESCRIPTION
closes #465 

Python version of Canvas Log Viewer supports shortname for deployment names. "idconf" and "credman" have been added:

![image](https://github.com/user-attachments/assets/fc3240d2-4be5-4c98-aada-77d62d979c98)


