### PR TITLE
[skip tests] update HashiCorp Vault installation documentation

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -1,5 +1,4 @@
-﻿﻿
-# ODA Canvas installation
+﻿# ODA Canvas installation
 
 The Reference Implementation of the ODA Canvas is a set of Helm charts that can be used to install and configure a fully working Canvas. The Reference Implementation is built on top of Kubernetes and Istio.
 
@@ -145,23 +144,11 @@ helm install istio-ingress istio/gateway -n istio-ingress --set labels.app=istio
 
 ### 4. HashiCorp Vault
 
-By default HashiCorp Vault is deployed into the namespace canvas-vault. 
-The deployment can be supressed when setting `canvas-vault.enabled` to `false` in the values.yaml:
+A setup script to deploy and configure HashiCorp Vault into the cluster and configure it to trust 
+the Service-Account-Issuer of this cluster is provided in CanvasVault/setup_CanvasVault.sh.
 
-https://github.com/tmforum-oda/oda-canvas/blob/21329156c71a361baaec0955fd244755d01f0227/charts/canvas-oda/values.yaml#L202-L203
-
-Instead of changing the values.yaml the value can also be overwritten on command line:
-
-```
-helm install canvas oda-canvas/canvas-oda -n canvas --create-namespace --set=canvas-vault.enabled=false
-```
-
-If HashiCorp Vault is **NOT** installed, everything works fine.
-The Secrets-Management-Operator `canvas-smanop` in the canvas namespace will have a failure with `CreateContainerConfigError`
-and if a component requests Secrets-Management
-it will not reach the state "Completed" but get stuck in state "InProgress-SecretsConfig".
-
-Components which do not request Secrets-Management will work without any errors.
+If HashiCorp Vault is **NOT** installed, everything works fine, only if a component requests Secrets-Management,
+it will get stuck in state "InProgress-SecretsConfig".
 
 
 ### 5. Reference implementation

--- a/installation/README.md
+++ b/installation/README.md
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 # ODA Canvas installation
 
 The Reference Implementation of the ODA Canvas is a set of Helm charts that can be used to install and configure a fully working Canvas. The Reference Implementation is built on top of Kubernetes and Istio.
@@ -145,11 +145,24 @@ helm install istio-ingress istio/gateway -n istio-ingress --set labels.app=istio
 
 ### 4. HashiCorp Vault
 
-A setup script to deploy and configure HashiCorp Vault into the cluster and configure it to trust 
-the Service-Account-Issuer of this cluster is provided in CanvasVault/setup_CanvasVault.sh.
+By default HashiCorp Vault is deployed into the namespace canvas-vault. 
+The deployment can be supressed when setting `canvas-vault.enabled` to `false` in the values.yaml:
 
-If HashiCorp Vault is **NOT** installed, everything works fine, only if a component requests Secrets-Management,
-it will get stuck in state "InProgress-SecretsConfig".
+https://github.com/tmforum-oda/oda-canvas/blob/21329156c71a361baaec0955fd244755d01f0227/charts/canvas-oda/values.yaml#L202-L203
+
+Instead of changing the values.yaml the value can also be overwritten on command line:
+
+```
+helm install canvas oda-canvas/canvas-oda -n canvas --create-namespace --set=canvas-vault.enabled=false
+```
+
+If HashiCorp Vault is **NOT** installed, everything works fine.
+The Secrets-Management-Operator `canvas-smanop` in the canvas namespace will have a failure with `CreateContainerConfigError`
+and if a component requests Secrets-Management
+it will not reach the state "Completed" but get stuck in state "InProgress-SecretsConfig".
+
+Components which do not request Secrets-Management will work without any errors.
+
 
 
 ### 5. Reference implementation

--- a/installation/README.md
+++ b/installation/README.md
@@ -156,10 +156,9 @@ Instead of changing the values.yaml the value can also be overwritten on command
 helm install canvas oda-canvas/canvas-oda -n canvas --create-namespace --set=canvas-vault.enabled=false
 ```
 
-If HashiCorp Vault is **NOT** installed, everything works fine.
-The Secrets-Management-Operator `canvas-smanop` in the canvas namespace will have a failure with `CreateContainerConfigError`
-and if a component requests Secrets-Management
-it will not reach the state "Completed" but get stuck in state "InProgress-SecretsConfig".
+If HashiCorp Vault is **NOT** installed:
+- everything works fine as long as Secrets-Management is not requested by any component. 
+- If Secrets-Management is needed by a component, this component will not reach the state "Completed" but get stuck in state "InProgress-SecretsConfig". Also the Secrets-Management-Operator `canvas-smanop` in the canvas namespace will have a failure with `CreateContainerConfigError`.
 
 Components which do not request Secrets-Management will work without any errors.
 

--- a/installation/README.md
+++ b/installation/README.md
@@ -145,12 +145,23 @@ helm install istio-ingress istio/gateway -n istio-ingress --set labels.app=istio
 
 ### 4. HashiCorp Vault
 
-A setup script to deploy and configure HashiCorp Vault into the cluster and configure it to trust 
-the Service-Account-Issuer of this cluster is provided in CanvasVault/setup_CanvasVault.sh.
+By default HashiCorp Vault is deployed into the namespace canvas-vault. 
+The deployment can be supressed when setting `canvas-vault.enabled` to `false` in the values.yaml:
 
-If HashiCorp Vault is **NOT** installed, everything works fine, only if a component requests Secrets-Management,
-it will get stuck in state "InProgress-SecretsConfig".
+https://github.com/tmforum-oda/oda-canvas/blob/21329156c71a361baaec0955fd244755d01f0227/charts/canvas-oda/values.yaml#L202-L203
 
+Instead of changing the values.yaml the value can also be overwritten on command line:
+
+```
+helm install canvas oda-canvas/canvas-oda -n canvas --create-namespace --set=canvas-vault.enabled=false
+```
+
+If HashiCorp Vault is **NOT** installed, everything works fine.
+The Secrets-Management-Operator `canvas-smanop` in the canvas namespace will have a failure with `CreateContainerConfigError`
+and if a component requests Secrets-Management
+it will not reach the state "Completed" but get stuck in state "InProgress-SecretsConfig".
+
+Components which do not request Secrets-Management will work without any errors.
 
 ### 5. Reference implementation
 


### PR DESCRIPTION
closes #472 

The installation instructions are outdated regarding the installation of HashiCorp Vault.

The text should be updated:
https://github.com/tmforum-oda/oda-canvas/blob/feature/472-documentation-canvas-vault-installation/installation/README.md#4-hashicorp-vault
