### PR TITLE
Fix Identityconfig-operator-keycloak Release Dockerimage job fail error

### DIFF
--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -166,7 +166,7 @@ identityconfig-operator-keycloak:
     operatrorName: identityconfig-operator-keycloak
     idkopImage: tmforumodacanvas/identityconfig-operator-keycloak
     idkopVersion: 1.0.3
-    idkopPrereleaseSuffix: issue413
+    idkopPrereleaseSuffix:
     imagePullPolicy: IfNotPresent
     istioGateway: true
     idlistkeyImage: tmforumodacanvas/identity-listener-keycloak


### PR DESCRIPTION
In this PR removed prerelease suffix to fix build identityconfig-operator-keycloak Release Dockerimage job fail error.