### PR TITLE
bugfix: ODA Canvas installation fails due to malformed namespace descriptors

### DIFF
--- a/charts/api-operator-istio/values.yaml
+++ b/charts/api-operator-istio/values.yaml
@@ -5,7 +5,9 @@ deployment:
   apiopPrereleaseSuffix:
   apiopImagePullPolicy: IfNotPresent
   istioGateway: true
-  monitoredNamespaces: 'components,odacompns-*'           # comma separated list of namespaces
+  monitoredNamespaces:
+    - components
+    - odacompns-*
   ingressClass:
     enabled: false
     name: nginx


### PR DESCRIPTION
Currently, installation of the bleeding edge version of the canvas fails with the following errors:

```
Error: INSTALLATION FAILED: 4 errors occurred:
	* namespaces "components,odacompns-*" not found
	* namespaces "components,odacompns-*" not found
	* namespaces "components,odacompns-*" not found
	* namespaces "components,odacompns-*" not found

```

this PR attempts to fix that. Related to https://github.com/tmforum-oda/oda-canvas/pull/480