### PR TITLE
487 tools and guidance to use ai coding assistants for developing canvas

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,63 @@
+# Copilot Instructions for TM Forum ODA Canvas
+
+## Project Overview
+
+This repository contains the Reference Implementation, open-source code, use cases, and test kit for a TM Forum Open Digital Architecture (ODA) Canvas. The ODA Canvas is an execution environment for ODA Components.
+
+## Key Concepts and Terminology
+
+- **ODA Canvas**: An execution environment that supports ODA Components by providing access to cloud-native services required by the components (API Gateway, Service Mesh, Observability services, Identity Management, etc.).
+- **ODA Component**: Software components that follow the ODA Component Specification, which the Canvas reads as metadata to execute lifecycle processes.
+- **Operators**: Management-plane functions that manage ODA Components by reading the Component's requirements and executing lifecycle processes. Operators follow the Kubernetes Operator Pattern.
+- **Webhooks**: Used to integrate with the Kubernetes Control Plane, supporting multiple versions of the ODA Component Standard.
+- **BDD (Behaviour-Driven Development)**: The approach used to document and test Canvas behaviors through features and scenarios.
+
+
+## Modular Architecture
+
+The ODA Canvas implements a modular architecture with independent operators:
+
+- **Component Management**: Manages the lifecycle of each component and handles decomposition into ExposedAPIs, IdentityConfigs, and other sub-resources.
+- **API Management**: Manages API Gateway and/or Service Mesh to provide security, throttling, and other non-functional services.
+- **Identity Config**: Configures Identity Management Services.
+- **Secrets Management**: Optional operator for configuring secrets.
+- **Dependency Management**: Allows Components to discover API dependencies.
+
+## Project Structure
+
+- **usecase-library/**: Contains use cases describing how ODA Components interact with the ODA Canvas
+- **feature-definition-and-test-kit/**: Details the features required for Canvas compliance and tests to validate implementations
+- **source/**: Contains source code for Canvas operators
+  - **operators/**: Key part of the Canvas that manages ODA Components
+  - **webhooks/**: Integrates with Kubernetes Control Plane
+  - **utilities/**: Tools for development and troubleshooting
+- **charts/**: Helm charts for deploying Canvas components
+- **installation/**: Installation guides and scripts
+- **docs/**: Additional documentation for developers
+
+## Development Guidelines
+
+When contributing to this project:
+
+1. Follow the code-of-conduct and contribution guidelines in CONTRIBUTING.md
+2. Use BDD for new features, starting with use cases and creating corresponding BDD scenarios
+3. Document design decisions in the Architecture Decision Log
+4. Include docstrings in source code
+5. Use GitHub issues for tracking work
+6. For operators, follow the Kubernetes Operator Pattern
+
+## Testing and Validation
+
+- BDD features and scenarios are used to create executable tests
+- The test kit validates Canvas implementations
+- Components are tested against the standard ODA Component Specification
+- Tests are automated to ensure compliance with security principles
+
+## Further Documentation
+
+For more detailed information, refer to:
+
+- Canvas-design.md: Overall Canvas design documentation
+- README.md: Main project introduction
+- SecurityPrinciples.md: Detailed security principles
+- Authentication-design.md, Event-based-integration-design.md, Observability-design.md: Design epic documentation

--- a/ai-coding-assistants.md
+++ b/ai-coding-assistants.md
@@ -1,0 +1,92 @@
+# AI Coding Assistants for ODA Canvas Development
+
+## Overview
+
+
+This document provides guidance on using osing assistants effectively within the ODA Canvas project, with a focus on enhancing developer productivity, encouraging consistent practices, and improving quality. 
+There are sections for different popular coding assistants (many initially populated with TBD - feel free to add to these sections if you are using that particular AI Coding Assistant).
+
+
+
+
+## GitHub Copilot
+
+This section gives guidance on using [GitHub Copilot](https://github.com/features/copilot). 
+It introduces advanced usage modes such as **Agent Mode**, discusses integration with **Model Context Protocol (MCP)**, and proposes the adoption of **Context7** to improve prompt clarity and reusability.
+
+---
+
+## GitHub Copilot: Best Practices
+
+GitHub Copilot is a context-aware AI assistant for code completion and suggestion. When used effectively, it can accelerate development of Canvas components, conformance assets, Helm charts, CRDs, and documentation.
+
+### Recommended Usage Scenarios
+- Scaffold Kubernetes manifests (e.g., Helm charts, CRDs)
+- Generate boilerplate for TMF Open APIs (e.g., TMF641)
+- Write test cases and mocks
+- Improve readability and add documentation
+
+### Prompt Engineering Tips
+- Comment your intent clearly before writing code
+- Include type hints and function signatures for better completions
+- Break tasks into small, well-scoped units
+
+```python
+# Define a Kubernetes CustomResourceDefinition for a Canvas component
+# The component must include metadata, spec, and status fields
+```
+
+---
+
+## Copilot instructions
+
+Copilot will read repo-specific instructions from a `.github/copilot-instructions.md` file. This allows you to define frameworks, sdks, coding style guides and other references to help with the consistency and quality of the copilot assistance.
+
+## Modes in Copilot 
+
+GitHub Copilot Labs includes three modes, **Ask** for using Copilot to answer questions on your codebase, **Edit** for editing individual files,
+and **Agent Mode**, which allows for longer-running assistance over multiple files and also supports integration with tools via [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction).
+
+
+
+## Integrating with Model Context Protocol (MCP)
+
+**MCP** is a standard for sharing structured context with AI systems. For ODA Canvas, you can apply MCP principles to:
+
+- Pass architectural context and component metadata to the assistant
+- Standardize prompts using structured context blocks
+- Improve the traceability and reproducibility of AI-generated code
+
+## Recommented MCP Tools
+
+### Context7
+
+[Context7](https://context7.com/) pulls up-to-date, version-specific documentation and code examples  and adds them to the coding assistant context.
+See [https://github.com/upstash/context7](https://github.com/upstash/context7) for details on how to install and use Context7.
+
+### GitHub MCP-Server
+
+[Github MCP Server](https://github.com/github/github-mcp-server) rovides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities. 
+It can interact with Issues, Pull Requests and code assets.
+
+### Gemini Code Assist
+
+[https://codeassist.google/](https://codeassist.google/)
+
+TBD 
+
+## Amazon Q Developer (formerly CodeWhisperer)
+
+[https://aws.amazon.com/q/developer/build](https://aws.amazon.com/q/developer/build)
+
+TBD
+
+## Cursor
+
+[https://www.cursor.com/](https://www.cursor.com/)
+
+TBD
+
+
+
+

--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -1978,7 +1978,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard
@@ -2127,7 +2128,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard
@@ -2160,7 +2162,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) APIs is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         specification:  
                           type: array
                           items:
@@ -2203,7 +2206,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) APIs is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         specification:  
                           type: array
                           items:
@@ -2265,7 +2269,9 @@ spec:
                           enum:
                           - openapi
                           - prometheus
-                          description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                          - openmetrics
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and Prometheus/OpenMetrics (metrics) and MCP APIs are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard                          
@@ -2413,7 +2419,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard                          
@@ -2489,7 +2496,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard                          
@@ -2637,7 +2645,8 @@ spec:
                           type: string
                           enum:
                           - openapi
-                          description: The type of API specification. Currently only OpenAPI (swagger) is supported.
+                          - mcp
+                          description: The type of API specification. Currently OpenAPI (swagger) and MCP are supported.
                         apiSDO:
                           type: string
                           description: (optional) The name of the SDO (Standards Definition Organization) that defines the API standard                          

--- a/charts/oda-crds/templates/oda-exposedapi-crd.yaml
+++ b/charts/oda-crds/templates/oda-exposedapi-crd.yaml
@@ -372,7 +372,9 @@ spec:
                 enum:
                 - openapi
                 - prometheus
-                description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus (metrics) APIs are supported.
+                - openmetrics
+                - mcp
+                description: The type of API specification. Currently only OpenAPI (swagger) and Prometheus/OpenMetrics (metrics) and MCP APIs are supported.
               apiKeyVerification:
                 type: object
                 description: (optional) 

--- a/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
+++ b/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
@@ -184,7 +184,10 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apitype" in spec.keys():
-                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
+                    if (
+                        spec["apiType"] == "prometheus"
+                        or spec["apiType"] == "openmetrics"
+                    ):
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,
@@ -597,6 +600,7 @@ def createOrPatchServiceMonitor(patch, spec, namespace, name, inHandler, compone
         )
         raise kopf.TemporaryError("Exception creating ServiceMonitor.")
 
+
 def get_virtualservices():
     """
     retrieve list of all VirtualServices in all namespaces
@@ -655,7 +659,6 @@ def check_vs_conflict(vs_namespace, vs_name, gateway, hostname, path):
             )
 
 
-
 def createOrPatchVirtualService(
     patch, spec, namespace, inAPIName, inHandler, componentName
 ):
@@ -696,7 +699,7 @@ def createOrPatchVirtualService(
                 "gateways": [gateway],
                 "http": [
                     {
-                       "match": [{"uri": {"prefix": path}}],
+                        "match": [{"uri": {"prefix": path}}],
                         "route": [
                             {
                                 "destination": {

--- a/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
+++ b/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
@@ -184,7 +184,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apitype" in spec.keys():
-                    if spec["apitype"] == "prometheus":
+                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,
@@ -214,7 +214,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
     )
     # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
     if "apitype" in spec.keys():
-        if spec["apitype"] == "prometheus":
+        if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
             # create a ServiceMonitor resource
             logWrapper(
                 logging.INFO,

--- a/source/operators/api-management/istio/apiOperatorIstio.py
+++ b/source/operators/api-management/istio/apiOperatorIstio.py
@@ -183,7 +183,10 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apiType of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apiType" in spec.keys():
-                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
+                    if (
+                        spec["apiType"] == "prometheus"
+                        or spec["apiType"] == "openmetrics"
+                    ):
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,

--- a/source/operators/api-management/istio/apiOperatorIstio.py
+++ b/source/operators/api-management/istio/apiOperatorIstio.py
@@ -183,7 +183,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apiType of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apiType" in spec.keys():
-                    if spec["apiType"] == "prometheus":
+                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,
@@ -213,7 +213,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
     )
     # if the apiType of the api is 'prometheus' then we need to also create a ServiceMonitor resource
     if "apiType" in spec.keys():
-        if spec["apiType"] == "prometheus":
+        if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
             # create a ServiceMonitor resource
             logWrapper(
                 logging.INFO,

--- a/source/operators/api-management/kong/apiOperatorIstiowithKong.py
+++ b/source/operators/api-management/kong/apiOperatorIstiowithKong.py
@@ -184,7 +184,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apitype" in spec.keys():
-                    if spec["apitype"] == "prometheus":
+                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,
@@ -214,7 +214,7 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
     )
     # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
     if "apitype" in spec.keys():
-        if spec["apitype"] == "prometheus":
+        if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
             # create a ServiceMonitor resource
             logWrapper(
                 logging.INFO,

--- a/source/operators/api-management/kong/apiOperatorIstiowithKong.py
+++ b/source/operators/api-management/kong/apiOperatorIstiowithKong.py
@@ -20,7 +20,7 @@ from kubernetes.client.rest import ApiException
 import os
 import re
 
-# Setup logging 
+# Setup logging
 logging_level = os.environ.get("LOGGING", logging.INFO)
 kopf_logger = logging.getLogger()
 kopf_logger.setLevel(logging.WARNING)
@@ -184,7 +184,10 @@ def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
                 )
                 # if the apitype of the api is 'prometheus' then we need to also create a ServiceMonitor resource
                 if "apitype" in spec.keys():
-                    if spec["apiType"] == "prometheus" or spec["apiType"] == "openmetrics":
+                    if (
+                        spec["apiType"] == "prometheus"
+                        or spec["apiType"] == "openmetrics"
+                    ):
                         # create a ServiceMonitor resource
                         logWrapper(
                             logging.INFO,
@@ -654,7 +657,6 @@ def check_vs_conflict(vs_namespace, vs_name, gateway, hostname, path):
             raise ValueError(
                 f"conflicting VirtualService '{other_name}.{other_namespace}'"
             )
-
 
 
 def createOrPatchVirtualService(

--- a/source/operators/api-management/kong/apiOperatorKong.py
+++ b/source/operators/api-management/kong/apiOperatorKong.py
@@ -37,7 +37,9 @@ VERSION = "v1"
 APIS_PLURAL = "exposedapis"
 
 
-REFERENCEGRANT_API_VERSION = "gateway.networking.k8s.io/v1beta1" # API group for Gateway API
+REFERENCEGRANT_API_VERSION = (
+    "gateway.networking.k8s.io/v1beta1"  # API group for Gateway API
+)
 REFERENCEGRANT_KIND = "ReferenceGrant"
 REFERENCEGRANT_PLURAL = "referencegrants"
 REFERENCEGRANT_GROUP = "gateway.networking.k8s.io"
@@ -135,12 +137,11 @@ def create_or_update_ingress(spec, name, namespace, meta, **kwargs):
     api_instance = kubernetes.client.CustomObjectsApi()
     ingress_name = f"kong-api-route-{name}"
     reference_name = f"kong-ref-grant-{name}"
-    #namespace = "components"
+    # namespace = "components"
     service_name = "istio-ingress"
     service_namespace = "istio-ingress"
     strip_path = "false"
     kong_gateway_namespace = "components"
-
 
     try:
         # Attempt to find if the path exists or not , will skip if no path
@@ -151,26 +152,30 @@ def create_or_update_ingress(spec, name, namespace, meta, **kwargs):
         # ReferenceGrant in the same namespace as the ExposedAPI ,skipping adoption for this as due to unknown issue k8s is not creating not logging any error. Removal handled separately in deletion.
         refgrant = {
             "apiVersion": REFERENCEGRANT_API_VERSION,
-            "kind":       REFERENCEGRANT_KIND,
+            "kind": REFERENCEGRANT_KIND,
             "metadata": {
-                "name":      reference_name,
+                "name": reference_name,
                 "namespace": service_namespace,
             },
             "spec": {
-                "from": [{
-                    "group":     REFERENCEGRANT_GROUP,
-                    "kind":      "HTTPRoute",
-                    "namespace": namespace,
-                }],
-                "to": [{
-                    "group":     "",
-                    "kind":      "Service",
-                    "name":      service_name,
-                }],
+                "from": [
+                    {
+                        "group": REFERENCEGRANT_GROUP,
+                        "kind": "HTTPRoute",
+                        "namespace": namespace,
+                    }
+                ],
+                "to": [
+                    {
+                        "group": "",
+                        "kind": "Service",
+                        "name": service_name,
+                    }
+                ],
             },
         }
-        #kopf.adopt(refgrant)
-        
+        # kopf.adopt(refgrant)
+
         try:
             api_instance.get_namespaced_custom_object(
                 group=REFERENCEGRANT_GROUP,
@@ -305,7 +310,7 @@ def manage_ratelimit(spec, name, namespace, meta, **kwargs):
 
     api_instance = kubernetes.client.CustomObjectsApi()
     plugin_name = f"rate-limit-{name}"
-    #namespace = "components"
+    # namespace = "components"
     group = "configuration.konghq.com"
     version = "v1"
     plural = "kongplugins"
@@ -399,7 +404,7 @@ def manage_apiauthentication(spec, name, namespace, meta, **kwargs):
 
     api_instance = kubernetes.client.CustomObjectsApi()
     plugin_name = f"apiauthentication-{name}"
-    #namespace = "components"
+    # namespace = "components"
     group = "configuration.konghq.com"
     version = "v1"
     plural = "kongplugins"
@@ -490,7 +495,7 @@ def manage_cors(spec, name, namespace, meta, **kwargs):
 
     api_instance = kubernetes.client.CustomObjectsApi()
     plugin_name = f"cors-{name}"
-    #namespace = "components"
+    # namespace = "components"
     group = "configuration.konghq.com"
     version = "v1"
     plural = "kongplugins"
@@ -590,7 +595,7 @@ def update_httproute_annotations(name, namespace, annotations):
     group = "gateway.networking.k8s.io"
     version = "v1"
     plural = "httproutes"
-    #namespace = "components"
+    # namespace = "components"
 
     try:
         # Fetch the current HTTPRoute to get the resourceVersion
@@ -817,16 +822,20 @@ def delete_api_lifecycle(meta, name, namespace, **kwargs):
 
     try:
         api_instance.delete_namespaced_custom_object(
-            group     = REFERENCEGRANT_GROUP,
-            version   = REFERENCEGRANT_VERSION,
-            namespace = service_namespace_istio_ingress,
-            plural    = REFERENCEGRANT_PLURAL,
-            name      = reference_name,
-            body      = kubernetes.client.V1DeleteOptions(),
+            group=REFERENCEGRANT_GROUP,
+            version=REFERENCEGRANT_VERSION,
+            namespace=service_namespace_istio_ingress,
+            plural=REFERENCEGRANT_PLURAL,
+            name=reference_name,
+            body=kubernetes.client.V1DeleteOptions(),
         )
-        logger.info(f"ReferenceGrant '{reference_name}' deleted from namespace '{service_namespace_istio_ingress}'.")
+        logger.info(
+            f"ReferenceGrant '{reference_name}' deleted from namespace '{service_namespace_istio_ingress}'."
+        )
     except ApiException as e:
         if e.status == 404:
-            logger.info(f"ReferenceGrant '{reference_name}' not present in namespace '{service_namespace_istio_ingress}'.(404).")
+            logger.info(
+                f"ReferenceGrant '{reference_name}' not present in namespace '{service_namespace_istio_ingress}'.(404)."
+            )
         else:
             logger.error(f"Failed to delete ReferenceGrant '{reference_name}': {e}")


### PR DESCRIPTION
Closes #487 

This is the first guidance of how to improve effectiveness of AI Coding assistants. Showing guidance for GitHub Copilot with placeholders for some other options.

I've included the minor change to the Component CRD and Exposed API CRD to extend the apiType to allow mcp.

I've also fixed a small number of linting issues.