### PR TITLE
Adding secrets management flag and making Apisix and Kong operators to pickup cluster changes when booting

### DIFF
--- a/charts/api-operator-istio/values.yaml
+++ b/charts/api-operator-istio/values.yaml
@@ -15,7 +15,7 @@ deployment:
     port: 8080
   hostName: "*"
   httpsRedirect: true
-  credentialName: istio-ingress-cert    
+  credentialName: istio-ingress-cert
 configmap:
   loglevel: '20'
   # publicHostname: 'components.example.com'

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -32,9 +32,9 @@ version: 1.2.3-rc3
 # version: 1.1.8-lt5 - updated istio,kong and apisix charts , added value validation schema , added canvas uninstall security to avoid uninstall in presence of components
 # version: 1.1.8-lt4 - Refactored and separated identity config operator from component operator
 # version: 1.1.8-ak1 - changed seccon to canvassystem, changed keycloak realm to odari , enabled tls for keycloak API endpoints
-# version: 1.1.8-rc6 - issue 320 - SecretsManagemnt-Operator and DependentAPI-Simple-Operator support Canvas Log Viewer format 
+# version: 1.1.8-rc6 - issue 320 - SecretsManagemnt-Operator and DependentAPI-Simple-Operator support Canvas Log Viewer format
 # version: 1.1.8-lt3 - refactoring of component-operator and api-operator-istio
-# version: 1.1.8-rc4 - issue 372 - deploy non-DEV Vault with persistence and autounseal 
+# version: 1.1.8-rc4 - issue 372 - deploy non-DEV Vault with persistence and autounseal
 # version: 1.1.8-lt1 - added componentMetadata and apiSDO to v1beta4 crds
 # version: 1.1.8-rc2 - make hostname and cert configurable for component gateway
 # version: 1.1.8-rc1 - fix linux/arm64 docker build for secretsmanagement-operator
@@ -50,7 +50,7 @@ version: 1.2.3-rc3
 # version: 1.1.5-rc4 - update component operator/istio operator/dependentapi operator with exposedapis and changing v1beta3 crds of these with camelcase apiType
 # version: 1.1.5-rc3 - ODAA-114: fix exception in DependentAPI-Operator
 # version: 1.1.5-rc2 - added dependentApiSimpleOperator functionality to fetch the defined dependent API ENDPOINT from apis custom resouce
-# version: 1.1.5-rc1 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2, 
+# version: 1.1.5-rc1 - ODAA-86: downgrade HashiCorp Vault to 1.14.8. Last version under MPLv2,
 #                  see https://www.hashicorp.com/license-faq#products-covered-by-bsl
 # version: 1.1.4 - added secretsmanagement-operator
 # version: 1.1.3 - updated dependentApiSimpleOperator to tmforum docker repo
@@ -84,7 +84,7 @@ dependencies:
     repository: 'file://../component-operator'
   - name: identityconfig-operator-keycloak
     version: "1.2.5"
-    repository: 'file://../identityconfig-operator-keycloak'  
+    repository: 'file://../identityconfig-operator-keycloak'
   - name: api-operator-istio
     version: "1.1.2"
     repository: 'file://../api-operator-istio'
@@ -96,6 +96,7 @@ dependencies:
   - name: secretsmanagement-operator
     version: "1.0.1"
     repository: 'file://../secretsmanagement-operator'
+    condition: canvas-vault.enabled
   - name: canvas-vault
     version: "1.0.1"
     repository: 'file://../canvas-vault'

--- a/source/operators/api-management/apache-apisix/apiOperatorApisix.py
+++ b/source/operators/api-management/apache-apisix/apiOperatorApisix.py
@@ -51,6 +51,7 @@ def configure(settings: kopf.OperatorSettings, **_):
 
 @kopf.on.create(GROUP, VERSION, APIS_PLURAL, retries=5)
 @kopf.on.update(GROUP, VERSION, APIS_PLURAL, retries=5)
+@kopf.on.resume(GROUP, VERSION, APIS_PLURAL, retries=5)
 def manage_api_lifecycle(spec, name, namespace, status, meta, logger, **kwargs):
     """
     Manages the lifecycle of an API by creating or updating the ApisixRoute, managing plugins, and handling error logging.

--- a/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
+++ b/source/operators/api-management/apache-apisix/apiOperatorIstiowithApisix.py
@@ -125,6 +125,7 @@ def safe_get(default_value, dictionary, *paths):
 
 @kopf.on.create(GROUP, VERSION, APIS_PLURAL, retries=5)
 @kopf.on.update(GROUP, VERSION, APIS_PLURAL, retries=5)
+@kopf.on.resume(GROUP, VERSION, APIS_PLURAL, retries=5)
 def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
     """Handler function for new or updated APIs.
 

--- a/source/operators/api-management/kong/apiOperatorIstiowithKong.py
+++ b/source/operators/api-management/kong/apiOperatorIstiowithKong.py
@@ -125,6 +125,7 @@ def safe_get(default_value, dictionary, *paths):
 
 @kopf.on.create(GROUP, VERSION, APIS_PLURAL, retries=5)
 @kopf.on.update(GROUP, VERSION, APIS_PLURAL, retries=5)
+@kopf.on.resume(GROUP, VERSION, APIS_PLURAL, retries=5)
 def apiStatus(meta, spec, status, namespace, labels, name, **kwargs):
     """Handler function for new or updated APIs.
 

--- a/source/operators/api-management/kong/apiOperatorKong.py
+++ b/source/operators/api-management/kong/apiOperatorKong.py
@@ -50,6 +50,7 @@ plural = "httproutes"  # The plural name of the kong route CRD - HTTPRoute resou
 
 @kopf.on.create(GROUP, VERSION, APIS_PLURAL, retries=5)
 @kopf.on.update(GROUP, VERSION, APIS_PLURAL, retries=5)
+@kopf.on.resume(GROUP, VERSION, APIS_PLURAL, retries=5)
 def manage_api_lifecycle(spec, name, namespace, status, meta, logger, **kwargs):
     """
     Handles the lifecycle events (creation and updates) for API resources.


### PR DESCRIPTION
- adding `@kopf.on.resume` to the Kong and Apisix operators to pickup cluster changes
- adding canvas-vault.enabled flag as a prerequisite to the secretsmanagement-operator