### PR TITLE
Fix to apply id consistently to exposedAPI and dependentAPI 

### DIFF
--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -2108,9 +2108,6 @@ spec:
                         name:
                           type: string
                           description: Name of the API that this component is dependent on
-                        id:
-                          type: string
-                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:

--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -2108,6 +2108,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API that this component is dependent on
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:
@@ -2249,6 +2252,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:
@@ -2400,6 +2406,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API that this component is dependent on
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:
@@ -2477,6 +2486,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:
@@ -2626,6 +2638,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API that this component is dependent on
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:

--- a/charts/oda-crds/templates/oda-component-crd.yaml
+++ b/charts/oda-crds/templates/oda-component-crd.yaml
@@ -1953,12 +1953,12 @@ spec:
                     items:
                       type: object
                       properties:
-                        id:
-                          type: string
-                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         name:
                           type: string
                           description: Name of the API
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:
@@ -2108,6 +2108,9 @@ spec:
                         name:
                           type: string
                           description: Name of the API that this component is dependent on
+                        id:
+                          type: string
+                          description: This is the id of the API. For TM Forum Open-APIs this would be TMFxxx e.g. TMF620 for Product Catalog Management.                      
                         specification:  
                           type: array
                           items:


### PR DESCRIPTION
Fix to apply id consistently to `exposedAPI` and `dependentAPI` in `coreFunction`, `managementFunction` and `securityFunction`. These are not used by Canvas but are part of Component definition