### PR TITLE
remove CUCUMBER_PUBLISH_TOKEN as this is not supported any longer

### DIFF
--- a/.github/workflows/trigger_tests.yml
+++ b/.github/workflows/trigger_tests.yml
@@ -198,7 +198,7 @@ jobs:
         export KEYCLOAK_PASSWORD=adpass 
         export KEYCLOAK_BASE_URL="http://localhost:8083/auth/"
         export KEYCLOAK_REALM=odari
-        export CUCUMBER_PUBLISH_TOKEN=9afda79b-9ea0-44ff-8359-7f381ade4bb6
+        #export CUCUMBER_PUBLISH_TOKEN=9afda79b-9ea0-44ff-8359-7f381ade4bb6
         npm start 2>&1 | tee /tmp/test_results.log
         kubectl get exposedapis -n components
         kubectl -n canvas logs deployment/component-operator | tee /tmp/component-operator.log


### PR DESCRIPTION
closes #500 

As Cucumber was given back to the Open-Source community from SmartBear,
long lived reports are not supported any longer:
https://reports.cucumber.io/faqs

Removing the TOKEN before calling the BDD tests should generate a report which is 24h available.
And hopefully fix the "check test success" GitHub Action.
