### PR TITLE
Rebased: Add support for custom/private docker registry and image pull secrets (from #445)

### DIFF
--- a/charts/api-operator-istio/Chart.yaml
+++ b/charts/api-operator-istio/Chart.yaml
@@ -17,6 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.1.2
 # version: 1.1.2 - issue 448 - make component-gateway configurable in env variables, support multiple component namespaces
+# version: 1.1.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.1 - Templatized hardcoded images
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.4 - added job to avoid istio-ingress to patch as Loadbalancer if present in any other type

--- a/charts/api-operator-istio/Chart.yaml
+++ b/charts/api-operator-istio/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
+# version: 1.1.3 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.2 - issue 448 - make component-gateway configurable in env variables, support multiple component namespaces
-# version: 1.1.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.1 - Templatized hardcoded images
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.4 - added job to avoid istio-ingress to patch as Loadbalancer if present in any other type

--- a/charts/api-operator-istio/templates/EnableIstioLB.yaml
+++ b/charts/api-operator-istio/templates/EnableIstioLB.yaml
@@ -9,9 +9,13 @@ spec:
   template:
     spec:
       serviceAccountName: apioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}  # Using kubectl image
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}  # Using kubectl image
         command:
           - /bin/sh
           - -c

--- a/charts/api-operator-istio/templates/_helpers.tpl
+++ b/charts/api-operator-istio/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full apiop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "api-operator-istio.apiopDockerimage" -}}
-  {{- .Values.deployment.apiopImage -}}:{{- .Values.deployment.apiopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.apiopImage -}}:{{- .Values.deployment.apiopVersion -}}
   {{- if .Values.deployment.apiopPrereleaseSuffix -}}
     -{{- .Values.deployment.apiopPrereleaseSuffix -}}
   {{- end -}}
@@ -83,7 +83,6 @@ overwrite apiop imagePullSecret with "Always" if prereleaseSuffix is set
   {{- end -}}
 {{- end -}}
 
-
 {{/*
 Create KOPF cli option for the comma seperated list of namespaces in monitoredNamespaces:
 "<ns1>,<ns1>,...<nsN>"-> "-n <ns1> -n <ns2> ... -n <nsN>" 
@@ -91,5 +90,4 @@ Create KOPF cli option for the comma seperated list of namespaces in monitoredNa
 {{- define "api-operator-istio.monitoredNamespacesCLIOpts" -}}
 {{- printf "-n %s" .Values.deployment.monitoredNamespaces | replace "," " -n " }}
 {{- end -}}
-
 

--- a/charts/api-operator-istio/templates/deployment.yaml
+++ b/charts/api-operator-istio/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "api-operator-istio.labels" . | nindent 8 }}
     spec:
       serviceAccountName: apioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "api-operator-istio.apiopDockerimage" . }}

--- a/charts/apigee-gateway/templates/Deployment.yaml
+++ b/charts/apigee-gateway/templates/Deployment.yaml
@@ -14,9 +14,13 @@ spec:
         app: {{ .Release.Name }}-apigeeistio-operator
     spec:
       serviceAccountName: apigeeapioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-apigeeistio-operator
-        image: {{ .Values.apigeeoperatorimage.repository }}
+        image: {{ include "docker.registry" .}}{{ .Values.apigeeoperatorimage.repository }}
         imagePullPolicy: {{ .Values.apigeeoperatorimage.pullPolicy }}
         env:
           - name: APIGEE_ORG

--- a/charts/apisix-gateway/Chart.yaml
+++ b/charts/apisix-gateway/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
+# version: 1.0.3 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.2 - updated chart name
-# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/apisix-gateway/Chart.yaml
+++ b/charts/apisix-gateway/Chart.yaml
@@ -17,6 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.0.2
 # version: 1.0.2 - updated chart name
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/apisix-gateway/templates/Deployment.yaml
+++ b/charts/apisix-gateway/templates/Deployment.yaml
@@ -14,9 +14,13 @@ spec:
         app: {{ .Release.Name }}-apisixistio-operator
     spec:
       serviceAccountName: apisixapioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       initContainers:
         - name: wait-apisix-admin
-          image: {{ .Values.initContainerImage }}
+          image: {{ include "docker.registry" .}}{{ .Values.initContainerImage }}
           command:
             - sh
             - -c

--- a/charts/apisix-gateway/templates/DisableIstioLB.yaml
+++ b/charts/apisix-gateway/templates/DisableIstioLB.yaml
@@ -10,9 +10,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/apisix-gateway/templates/_helpers.tpl
+++ b/charts/apisix-gateway/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full apisix docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "api-operator-apisix.apisixopDockerimage" -}}
-  {{- .Values.apisixoperatorimage.apisixopImage -}}:{{- .Values.apisixoperatorimage.apisixopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.apisixoperatorimage.apisixopImage -}}:{{- .Values.apisixoperatorimage.apisixopVersion -}}
   {{- if .Values.apisixoperatorimage.apisixopPrereleaseSuffix -}}
     -{{- .Values.apisixoperatorimage.apisixopPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/canvas-info-service/Chart.yaml
+++ b/charts/canvas-info-service/Chart.yaml
@@ -4,7 +4,8 @@ description: The Canvas Info Service
 
 type: application
 
-version: 1.0.0
+version: 1.0.1
+# version: 1.0.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.0 - initial version
 
 appVersion: "1.0.0"

--- a/charts/canvas-info-service/templates/_helpers.tpl
+++ b/charts/canvas-info-service/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full dependent api docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "canvas-info-service.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}

--- a/charts/canvas-info-service/templates/infoservice-deployment.yaml
+++ b/charts/canvas-info-service/templates/infoservice-deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         app: {{ .Release.Name }}-info-service
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-info-service
         image: {{ include "canvas-info-service.dockerimage" . }}

--- a/charts/canvas-info-service/templates/mongodb-deployment.yaml
+++ b/charts/canvas-info-service/templates/mongodb-deployment.yaml
@@ -14,9 +14,13 @@ spec:
       labels:
         app: {{.Release.Name}}-svcinv-mongodb
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Release.Name}}-svcinv-mongodb
-        image: {{ .Values.mongodb.image }}
+        image: {{ include "docker.registry" .}}{{ .Values.mongodb.image }}
         ports:
         - name: svcinv-mongodb
           containerPort: {{.Values.mongodb.port}}

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -1,7 +1,20 @@
 apiVersion: v2
 name: canvas-oda
 description: A Helm of helm to orchestrate the ODA installation
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.2.4-LM1
 # version:  1.2.4-LM1- Added support for custom/private docker registry and image pull secrets
 # version:  1.2.4-LT1- added permissionSpecificationSet API for configuring roles

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -1,21 +1,7 @@
 apiVersion: v2
 name: canvas-oda
 description: A Helm of helm to orchestrate the ODA installation
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-
 version: 1.2.4-LT1
 # version:  1.2.4-LT1- added permissionSpecificationSet API for configuring roles
 # version: 1.2.3     - June release, prior to DTW
@@ -28,6 +14,7 @@ version: 1.2.4-LT1
 # version: 1.2.2-ak1 - created credentialsmanagement-operator client in keycloak and added permissions to query keycloak clients
 # version: 1.2.2-lt1 - Fixed webhook issue 439
 # version: 1.2.1-rc2 - Resolved chart name to values mapping for kong and apisix charts observed in 1.2.0 release
+# version: 1.2.1-rc2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.1-rc1 - Templatized hardcoded images
 # version: 1.2.0     - initial release of v1 component specification
 # version: 1.1.8     - released version
@@ -61,9 +48,6 @@ version: 1.2.4-LT1
 # version: 1.1.1 - bug fix for empty specification property of exposedAPI
 # version: 1.1.0 - updated component CRD to support an array for the specification field in the exposed API (to support Gen5 APIs)
 # version: 1.0.0 - baseline version
-
-# This is the version number of the application being deployed. We are versioning the canvas as the
-# version of the latest component spec that it supports.
 appVersion: "v1"
 
 dependencies:

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: canvas-oda
 description: A Helm of helm to orchestrate the ODA installation
 type: application
-version: 1.2.4-LT1
+version: 1.2.4-LM1
+# version:  1.2.4-LM1- Added support for custom/private docker registry and image pull secrets
 # version:  1.2.4-LT1- added permissionSpecificationSet API for configuring roles
 # version: 1.2.3     - June release, prior to DTW
 # version: 1.2.3-rc4 - issue 484 - extract canvas-info-service subchart from dependentapi-simple-operator
@@ -52,7 +53,7 @@ appVersion: "v1"
 
 dependencies:
   - name: cert-manager-init
-    version: "1.1.1"
+    version: "1.1.2"
     repository: 'file://../cert-manager-init'
   - name: canvas-namespaces
     version: "1.0.1"
@@ -67,17 +68,17 @@ dependencies:
     repository: 'https://charts.bitnami.com/bitnami'
     condition: keycloak.enabled
   - name: component-operator
-    version: "1.4.0"
+    version: "1.4.1"
     repository: 'file://../component-operator'
   - name: identityconfig-operator-keycloak
-    version: "1.2.6"
+    version: "1.2.7"
     repository: 'file://../identityconfig-operator-keycloak'  
   - name: api-operator-istio
-    version: "1.1.2"
+    version: "1.1.3"
     repository: 'file://../api-operator-istio'
     condition: api-operator-istio.enabled
   - name: dependentapi-simple-operator
-    version: "1.0.2"
+    version: "1.0.3"
     repository: 'file://../dependentapi-simple-operator'
     condition: dependentapi-simple-operator.enabled
   - name: secretsmanagement-operator
@@ -88,14 +89,14 @@ dependencies:
     repository: 'file://../canvas-vault'
     condition: canvas-vault.enabled
   - name: oda-webhook
-    version: "1.2.1"
+    version: "1.2.2"
     repository: 'file://../oda-webhook'
   - name: api-operator-kong
-    version: "1.0.2"
+    version: "1.0.3"
     repository: 'file://../kong-gateway'
     condition: kong-gateway-install.enabled
   - name: api-operator-apisix
-    version: "1.0.2"
+    version: "1.0.3"
     repository: 'file://../apisix-gateway'
     condition: apisix-gateway-install.enabled
   - name: canvas-info-service

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -14,8 +14,7 @@ version: 1.2.4-LM1
 # version: 1.2.2-ak2 - updated identityconfig-operator docker image version number to resolve deployment status issue
 # version: 1.2.2-ak1 - created credentialsmanagement-operator client in keycloak and added permissions to query keycloak clients
 # version: 1.2.2-lt1 - Fixed webhook issue 439
-# version: 1.2.1-rc2 - Resolved chart name to values mapping for kong and apisix charts observed in 1.2.0 release
-# version: 1.2.1-rc2 - Added support for custom/private docker registry and image pull secrets
+# version: 1.2.1-rc2 - Resolved chart name to values mapping for kong and apisix charts observed in 1.2.0 release, added support for custom/private docker registry and image pull secrets
 # version: 1.2.1-rc1 - Templatized hardcoded images
 # version: 1.2.0     - initial release of v1 component specification
 # version: 1.1.8     - released version
@@ -100,6 +99,6 @@ dependencies:
     repository: 'file://../apisix-gateway'
     condition: apisix-gateway-install.enabled
   - name: canvas-info-service
-    version: "1.0.0"
+    version: "1.0.1"
     repository: 'file://../canvas-info-service'
     condition: canvas-info-service.enabled

--- a/charts/canvas-oda/Chart.yaml
+++ b/charts/canvas-oda/Chart.yaml
@@ -82,10 +82,10 @@ dependencies:
     repository: 'file://../dependentapi-simple-operator'
     condition: dependentapi-simple-operator.enabled
   - name: secretsmanagement-operator
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../secretsmanagement-operator'
   - name: canvas-vault
-    version: "1.0.1"
+    version: "1.0.2"
     repository: 'file://../canvas-vault'
     condition: canvas-vault.enabled
   - name: oda-webhook

--- a/charts/canvas-oda/templates/_helpers.tpl
+++ b/charts/canvas-oda/templates/_helpers.tpl
@@ -60,3 +60,27 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Custom/private docker image registry
+*/}}
+{{- define "docker.registry" -}}
+{{- if .Values.global.image.registry }}
+{{- $registry := (trimSuffix "/" .Values.global.image.registry) }}
+{{- printf "%s/" $registry }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create image pull secrets
+*/}}
+{{- define "image-pull-secrets" -}}
+{{- range .Values.global.imagePullSecrets }}
+  {{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | nindent 0 | trim }}
+  {{- else }}
+- name: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
+++ b/charts/canvas-oda/templates/component-pre-uninstall-check.yaml
@@ -11,9 +11,13 @@ spec:
   template:
     spec:
       serviceAccountName: odacomponent-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
         - name: component-checker
-          image: {{ .Values.global.hookImages.kubectl }}
+          image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
           command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/templates/prehook.yaml
+++ b/charts/canvas-oda/templates/prehook.yaml
@@ -11,9 +11,13 @@ spec:
   template:
     spec:
       serviceAccount: canvas-sm-prehook-sa
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: check-istio
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
             - /bin/sh
             - -c

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -6,7 +6,7 @@
   # Declare variables to be passed into your templates.
 global:
   image:
-    # docker registry to pull images from
+    # docker registry to pull images from, e.g. "myreg.io/" (include the trailing slash)
     registry: ""
   
   # image pull secret to pull images from private registry

--- a/charts/canvas-oda/values.yaml
+++ b/charts/canvas-oda/values.yaml
@@ -5,6 +5,16 @@
   # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 global:
+  image:
+    # docker registry to pull images from
+    registry: ""
+  
+  # image pull secret to pull images from private registry
+  imagePullSecrets: []
+  # imagePullSecrts:
+  # - imagepullsecret1
+  # - imagepullsecret2
+
   certificate:
     # -- Name of the certificate and webhook |
     appName: "compcrdwebhook"

--- a/charts/canvas-vault/Chart.yaml
+++ b/charts/canvas-vault/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.2.1 - issue 372 - deploy non-DEV Vault with persistence and autounseal 

--- a/charts/canvas-vault/templates/autounseal-cronjob.yaml
+++ b/charts/canvas-vault/templates/autounseal-cronjob.yaml
@@ -13,10 +13,14 @@ spec:
       ttlSecondsAfterFinished: 3600
       template:
         spec:
+          {{- if .Values.global.imagePullSecrets }}
+          imagePullSecrets:
+          {{- include "image-pull-secrets" . |nindent 10 }}
+          {{- end }}
           containers:
           - name: autounsealvault
             # TODO[FH] remove suffix before merging to master/main
-            image: {{ .Values.global.hookImages.kubectlCurl }}
+            image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
             imagePullPolicy: IfNotPresent
             env:
             - name: VAULT_ADDR

--- a/charts/canvas-vault/templates/post-install-hook.yaml
+++ b/charts/canvas-vault/templates/post-install-hook.yaml
@@ -23,11 +23,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: post-install-job
         # TODO[FH] remove suffix before merging to master/main
-        image: {{ .Values.global.hookImages.kubectlCurl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting canvas vault post install hook;

--- a/charts/cert-manager-init/Chart.yaml
+++ b/charts/cert-manager-init/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
+# version: 1.1.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.1.1 - Templatized hardcoded images
 # version: 1.1.0 - updated to use v1 of CRD spec
 # version: 1.0.2 - updated appVersion to v1beta4

--- a/charts/cert-manager-init/templates/webhook.yaml
+++ b/charts/cert-manager-init/templates/webhook.yaml
@@ -15,9 +15,13 @@ metadata:
 spec:
   template:
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
         - name: post-install
-          image: {{ .Values.global.hookImages.busybox }}
+          image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.busybox }}
           imagePullPolicy: IfNotPresent
           command: ['sleep', '{{- $delay}}']
       restartPolicy: OnFailure

--- a/charts/component-operator/Chart.yaml
+++ b/charts/component-operator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.4.1
+# version: 1.4.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.4.0 - Added support for User Roles and Permissions API
 # version: 1.3.1 - issue 448 - support multiple component namespaces: remove namespaced role, fix KOPF command
-# version: 1.3.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.3.0 - updated to use v1 of CRD spec
 # version: 1.2.2 - changed seccon user to canvassystem and keycloak realm to odari
 # version: 1.2.1 - removed operator-command configMap - no longer using entrypoint.sh

--- a/charts/component-operator/Chart.yaml
+++ b/charts/component-operator/Chart.yaml
@@ -18,6 +18,7 @@ type: application
 version: 1.4.0
 # version: 1.4.0 - Added support for User Roles and Permissions API
 # version: 1.3.1 - issue 448 - support multiple component namespaces: remove namespaced role, fix KOPF command
+# version: 1.3.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.3.0 - updated to use v1 of CRD spec
 # version: 1.2.2 - changed seccon user to canvassystem and keycloak realm to odari
 # version: 1.2.1 - removed operator-command configMap - no longer using entrypoint.sh

--- a/charts/component-operator/templates/_helpers.tpl
+++ b/charts/component-operator/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full compop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "component-operator.compopDockerimage" -}}
-  {{- .Values.deployment.compopImage -}}:{{- .Values.deployment.compopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.compopImage -}}:{{- .Values.deployment.compopVersion -}}
   {{- if .Values.deployment.compopPrereleaseSuffix -}}
     -{{- .Values.deployment.compopPrereleaseSuffix -}}
   {{- end -}}
@@ -91,5 +91,3 @@ Create KOPF cli option for the comma seperated list of namespaces in monitoredNa
 {{- define "component-operator.monitoredNamespacesCLIOpts" -}}
 {{- printf "-n %s" .Values.deployment.monitoredNamespaces | replace "," " -n " }}
 {{- end -}}
-
-

--- a/charts/component-operator/templates/deployment.yaml
+++ b/charts/component-operator/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "component-operator.labels" . | nindent 8 }}
     spec:
       serviceAccountName: odacomponent-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "component-operator.compopDockerimage" . }}

--- a/charts/credentialsmanagement-operator/templates/_helpers.tpl
+++ b/charts/credentialsmanagement-operator/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full credop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "credentialsmanagement-operator.credopImage" -}}
-  {{- .Values.deployment.credopImage -}}:{{- .Values.deployment.credopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.credopImage -}}:{{- .Values.deployment.credopVersion -}}
   {{- if .Values.deployment.credopPrereleaseSuffix -}}
     -{{- .Values.deployment.credopPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/credentialsmanagement-operator/templates/deployment.yaml
+++ b/charts/credentialsmanagement-operator/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "credentialsmanagement-operator.labels" . | nindent 8 }}
     spec:
       serviceAccountName: credentialsmanagement-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "credentialsmanagement-operator.credopImage" . }}

--- a/charts/dependentapi-simple-operator/Chart.yaml
+++ b/charts/dependentapi-simple-operator/Chart.yaml
@@ -17,6 +17,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.0.2
 # version: 1.0.2 - remove canvas info service
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.3.0 - issue 414 - Updated structure of specification url in dependentApi resource

--- a/charts/dependentapi-simple-operator/Chart.yaml
+++ b/charts/dependentapi-simple-operator/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
+# version: 1.0.3 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.2 - remove canvas info service
-# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.3.0 - issue 414 - Updated structure of specification url in dependentApi resource

--- a/charts/dependentapi-simple-operator/templates/_helpers.tpl
+++ b/charts/dependentapi-simple-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full dependent api docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "dependentapi-simple-operator.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}
@@ -25,7 +25,7 @@ overwrite imagePullSecret with "Always" if prereleaseSuffix is set
 build the full dependent api docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "dependentapi-serviceinventoryapi.dockerimage" -}}
-  {{- .Values.serviceInventoryAPI.image -}}:{{- .Values.serviceInventoryAPI.version -}}
+  {{ include "docker.registry" .}}{{- .Values.serviceInventoryAPI.image -}}:{{- .Values.serviceInventoryAPI.version -}}
   {{- if .Values.serviceInventoryAPI.prereleaseSuffix -}}
     -{{- .Values.serviceInventoryAPI.prereleaseSuffix -}}
   {{- end -}}

--- a/charts/dependentapi-simple-operator/templates/depapi-operator-deployment.yaml
+++ b/charts/dependentapi-simple-operator/templates/depapi-operator-deployment.yaml
@@ -15,6 +15,10 @@ spec:
         app: {{ .Release.Name }}-depapi-op
     spec:
       serviceAccountName: {{ .Release.Name }}-depapi-op-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-depapi-op
         image: {{ include "dependentapi-simple-operator.dockerimage" . }}

--- a/charts/identityconfig-operator-keycloak/Chart.yaml
+++ b/charts/identityconfig-operator-keycloak/Chart.yaml
@@ -23,6 +23,7 @@ version: 1.2.6
 # version: 1.2.3 - issue 362 - set serviceAccountsEnabled to true when creating new clients
 # version: 1.2.2 - updated listener docker image to remove vulnerabilities
 # version: 1.2.1 - Added startup handler with api server watcher timeout
+# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to use v1 of CRD spec
 # version: 1.1.0 - changed controllerRole to canvasSystemRole
 # version: 1.0.0 - initial version - identityconfig separated out from component operator

--- a/charts/identityconfig-operator-keycloak/Chart.yaml
+++ b/charts/identityconfig-operator-keycloak/Chart.yaml
@@ -16,14 +16,14 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.2.6
+version: 1.2.7
+# version: 1.2.7 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.6 - issue 81 - added permissionSpecificationSet API for configuring roles
 # version: 1.2.5 - issue 448 - support multiple component namespaces: remove namespaced role, fix KOPF command
 # version: 1.2.4 - Add canvasSystemRole to canvassystem client
 # version: 1.2.3 - issue 362 - set serviceAccountsEnabled to true when creating new clients
 # version: 1.2.2 - updated listener docker image to remove vulnerabilities
 # version: 1.2.1 - Added startup handler with api server watcher timeout
-# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to use v1 of CRD spec
 # version: 1.1.0 - changed controllerRole to canvasSystemRole
 # version: 1.0.0 - initial version - identityconfig separated out from component operator

--- a/charts/identityconfig-operator-keycloak/templates/_helpers.tpl
+++ b/charts/identityconfig-operator-keycloak/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full idkop docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "identityconfig-operator-keycloak.idkopImage" -}}
-  {{- .Values.deployment.idkopImage -}}:{{- .Values.deployment.idkopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.idkopImage -}}:{{- .Values.deployment.idkopVersion -}}
   {{- if .Values.deployment.idkopPrereleaseSuffix -}}
     -{{- .Values.deployment.idkopPrereleaseSuffix -}}
   {{- end -}}
@@ -76,7 +76,7 @@ build the full idkop docker image name from image + version + prereleaseSuffix
 build the full idlistkey docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "identityconfig-operator-keycloak.idlistkeyImage" -}}
-  {{- .Values.deployment.idlistkeyImage -}}:{{- .Values.deployment.idlistkeyVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.deployment.idlistkeyImage -}}:{{- .Values.deployment.idlistkeyVersion -}}
   {{- if .Values.deployment.idlistkeyPrereleaseSuffix -}}
     -{{- .Values.deployment.idlistkeyPrereleaseSuffix -}}
   {{- end -}}
@@ -102,6 +102,3 @@ Create KOPF cli option for the comma seperated list of namespaces in monitoredNa
 {{- define "identityconfig-operator-keycloak.monitoredNamespacesCLIOpts" -}}
 {{- printf "-n %s" .Values.deployment.monitoredNamespaces | replace "," " -n " }}
 {{- end -}}
-
-
-

--- a/charts/identityconfig-operator-keycloak/templates/deployment.yaml
+++ b/charts/identityconfig-operator-keycloak/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "identityconfig-operator-keycloak.labels" . | nindent 8 }}
     spec:
       serviceAccountName: identityconfig-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{.Values.deployment.operatorName}}
         image: {{ include "identityconfig-operator-keycloak.idkopImage" . }}

--- a/charts/kong-gateway/Chart.yaml
+++ b/charts/kong-gateway/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.0.2
+version: 1.0.3
+# version: 1.0.3 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.2 - updated chart name
-# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/kong-gateway/Chart.yaml
+++ b/charts/kong-gateway/Chart.yaml
@@ -18,6 +18,7 @@ type: application
 
 version: 1.0.2
 # version: 1.0.2 - updated chart name
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.4 - added with latest updates to v1beta4 crds

--- a/charts/kong-gateway/templates/Deployment.yaml
+++ b/charts/kong-gateway/templates/Deployment.yaml
@@ -14,9 +14,13 @@ spec:
         app: {{ .Release.Name }}-kongistio-operator
     spec:
       serviceAccountName: kongapioperator-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       initContainers:
         - name: wait-kong-admin
-          image: {{ .Values.initContainerImage }}
+          image: {{ include "docker.registry" .}}{{ .Values.initContainerImage }}
           command:
             - sh
             - -c

--- a/charts/kong-gateway/templates/DisableIstioLB.yaml
+++ b/charts/kong-gateway/templates/DisableIstioLB.yaml
@@ -10,9 +10,13 @@ spec:
   template:
     spec:
       serviceAccountName: {{ .Release.Name }}-operator
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: patch-istio-ingress
-        image: {{ .Values.global.hookImages.kubectl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectl }}
         command:
           - /bin/sh
           - -c

--- a/charts/kong-gateway/templates/_helpers.tpl
+++ b/charts/kong-gateway/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full kong docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "api-operator-kong.kongopDockerimage" -}}
-  {{- .Values.kongoperatorimage.kongopImage -}}:{{- .Values.kongoperatorimage.kongopVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.kongoperatorimage.kongopImage -}}:{{- .Values.kongoperatorimage.kongopVersion -}}
   {{- if .Values.kongoperatorimage.kongopPrereleaseSuffix -}}
     -{{- .Values.kongoperatorimage.kongopPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/oda-webhook/Chart.yaml
+++ b/charts/oda-webhook/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
+# version: 1.2.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.1 - Fixed webhook issue 439
-# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to support v1 of CRD spec (and remove v1beta1)
 # version: 1.1.4 - added componentMetadata and apiSDO to v1beta4 crds
 # version: 1.1.3 - added v1beta4 crds and removed v1alpha crds

--- a/charts/oda-webhook/Chart.yaml
+++ b/charts/oda-webhook/Chart.yaml
@@ -15,8 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1 
+version: 1.2.1
 # version: 1.2.1 - Fixed webhook issue 439
+# version: 1.2.1 - Added support for custom/private docker registry and image pull secrets
 # version: 1.2.0 - updated to support v1 of CRD spec (and remove v1beta1)
 # version: 1.1.4 - added componentMetadata and apiSDO to v1beta4 crds
 # version: 1.1.3 - added v1beta4 crds and removed v1alpha crds

--- a/charts/oda-webhook/templates/_helpers.tpl
+++ b/charts/oda-webhook/templates/_helpers.tpl
@@ -65,7 +65,7 @@ Create the name of the service account to use
 build the full oda-webhook docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "oda-webhook.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}

--- a/charts/oda-webhook/templates/deployment-componentcrdwebhook.yaml
+++ b/charts/oda-webhook/templates/deployment-componentcrdwebhook.yaml
@@ -16,6 +16,10 @@ spec:
         app: compcrdwebhook 
         {{- include "oda-webhook.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: compcrdwebhook 
         image: {{ include "oda-webhook.dockerimage" . }}

--- a/charts/secretsmanagement-operator/Chart.yaml
+++ b/charts/secretsmanagement-operator/Chart.yaml
@@ -15,7 +15,8 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
+# version: 1.0.2 - Added support for custom/private docker registry and image pull secrets
 # version: 1.0.1 - Templatized hardcoded images
 # version: 1.0.0 - updated to use v1 of CRD spec
 # version: 0.1.3 - issue 320 - SecretsManagemnt-Operator supports Canvas Log Viewer format 

--- a/charts/secretsmanagement-operator/templates/_helpers.tpl
+++ b/charts/secretsmanagement-operator/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 build the full docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "secretsmanagementoperator.dockerimage" -}}
-  {{- .Values.image -}}:{{- .Values.version -}}
+  {{ include "docker.registry" .}}{{- .Values.image -}}:{{- .Values.version -}}
   {{- if .Values.prereleaseSuffix -}}
     -{{- .Values.prereleaseSuffix -}}
   {{- end -}}
@@ -13,7 +13,7 @@ build the full docker image name from image + version + prereleaseSuffix
 build the full sidecar docker image name from image + version + prereleaseSuffix
 */}}
 {{- define "secretsmanagementoperator.sidecarDockerimage" -}}
-  {{- .Values.sidecarImage -}}:{{- .Values.sidecarVersion -}}
+  {{ include "docker.registry" .}}{{- .Values.sidecarImage -}}:{{- .Values.sidecarVersion -}}
   {{- if .Values.sidecarPrereleaseSuffix -}}
     -{{- .Values.sidecarPrereleaseSuffix -}}
   {{- end -}}

--- a/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
+++ b/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
@@ -31,7 +31,6 @@ spec:
       restartPolicy: Never
       containers:
       - name: autodetect-audience
-        # TODO[FH]: remove prereleasesuffix
         image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]

--- a/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
+++ b/charts/secretsmanagement-operator/templates/preinst-autodetect-audience-job.yaml
@@ -24,11 +24,15 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: autodetect-audience
         # TODO[FH]: remove prereleasesuffix
-        image: {{ .Values.global.hookImages.kubectlCurl }}
+        image: {{ include "docker.registry" .}}{{ .Values.global.hookImages.kubectlCurl }}
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh"]
         args: ["-c", "echo starting autodetect audience pre install hook;

--- a/charts/secretsmanagement-operator/templates/smanop-deployment.yaml
+++ b/charts/secretsmanagement-operator/templates/smanop-deployment.yaml
@@ -15,6 +15,10 @@ spec:
         app: {{ .Release.Name }}-smanop
     spec:
       serviceAccountName: {{ .Release.Name }}-smanop-account
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "image-pull-secrets" . |nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Release.Name }}-smanop
         image: {{ include "secretsmanagementoperator.dockerimage" . }}


### PR DESCRIPTION
This PR revives and updates the changes from the original PR #445 ("Added support for custom/private docker registry and image pull secrets") by the previous contributor.

- The original branch was orphaned and out of date.
- This feature branch has been rebased on top of the latest main branch, with all conflicts carefully resolved.

References:
- Original PR: #445
- Related issue: #444