### PR TITLE
Trigger missing build of Docker image api-operator-istio version 1.1.0

### DIFF
--- a/source/operators/api-management/istio/README.md
+++ b/source/operators/api-management/istio/README.md
@@ -59,3 +59,4 @@ You need to ensure you turn-off the operator execusing in Kubernetes (for exampl
 
 The command above will execute just the ExposedAPI operator. You will also need to execute the other operators relevant for your Canvas implementation - these can be executed in separate terminal command-lines.
 
+


### PR DESCRIPTION
closes #579 

https://hub.docker.com/r/tmforumodacanvas/api-operator-istio/tags?name=1.1.0

<img width="1913" height="1112" alt="image" src="https://github.com/user-attachments/assets/362cf6ed-12d4-427b-9ac5-04961e06f9cf" />
